### PR TITLE
RSDK-9780 fix nil readings error

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -53,6 +53,8 @@ var Model = resource.NewModel("viam", "lorawan", "sx1302-gateway")
 // the logging routine once.
 var loggingRoutineStarted = make(map[string]bool)
 
+var noReadings = map[string]interface{}{"": "no readings available yet"}
+
 // Config describes the configuration of the gateway
 type Config struct {
 	Bus       int    `json:"spi_bus,omitempty"`
@@ -524,7 +526,7 @@ func (g *gateway) Readings(ctx context.Context, extra map[string]interface{}) (m
 		if extra[data.FromDMString] == true {
 			return map[string]interface{}{}, data.ErrNoCaptureToStore
 		}
-		return map[string]interface{}{"": "no readings available yet"}, nil
+		return noReadings, nil
 	}
 
 	return g.lastReadings, nil

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -519,11 +519,12 @@ func (g *gateway) Readings(ctx context.Context, extra map[string]interface{}) (m
 	defer g.readingsMu.Unlock()
 
 	// no readings available yet
-	if len(g.lastReadings) == 0 {
+	if len(g.lastReadings) == 0 || g.lastReadings == nil {
 		// Tell the collector not to capture the empty data.
 		if extra[data.FromDMString] == true {
 			return map[string]interface{}{}, data.ErrNoCaptureToStore
 		}
+		return map[string]interface{}{"": "no readings available yet"}, nil
 	}
 
 	return g.lastReadings, nil

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -259,7 +259,7 @@ func TestReadings(t *testing.T) {
 	// If lastReadings is empty and the call is not from data manager, return no error.
 	readings, err := g.Readings(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{})
+	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
 
 	// If lastReadings is empty and the call is from data manager, return ErrNoCaptureToStore
 	_, err = g.Readings(context.Background(), map[string]interface{}{data.FromDMString: true})
@@ -268,7 +268,7 @@ func TestReadings(t *testing.T) {
 	// If data.FromDmString is false, return no error
 	_, err = g.Readings(context.Background(), map[string]interface{}{data.FromDMString: false})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{})
+	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
 
 	// successful readings call test case.
 	expectedReadings := map[string]interface{}{

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -259,7 +259,7 @@ func TestReadings(t *testing.T) {
 	// If lastReadings is empty and the call is not from data manager, return no error.
 	readings, err := g.Readings(context.Background(), nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
+	test.That(t, readings, test.ShouldResemble, noReadings)
 
 	// If lastReadings is empty and the call is from data manager, return ErrNoCaptureToStore
 	_, err = g.Readings(context.Background(), map[string]interface{}{data.FromDMString: true})
@@ -268,7 +268,7 @@ func TestReadings(t *testing.T) {
 	// If data.FromDmString is false, return no error
 	_, err = g.Readings(context.Background(), map[string]interface{}{data.FromDMString: false})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
+	test.That(t, readings, test.ShouldResemble, noReadings)
 
 	// successful readings call test case.
 	expectedReadings := map[string]interface{}{

--- a/node/node.go
+++ b/node/node.go
@@ -303,7 +303,7 @@ func (n *Node) Readings(ctx context.Context, extra map[string]interface{}) (map[
 			if extra[data.FromDMString] == true {
 				return map[string]interface{}{}, data.ErrNoCaptureToStore
 			}
-			return map[string]interface{}{}, nil
+			return map[string]interface{}{"": "no readings available yet"}, nil
 		}
 		return reading.(map[string]interface{}), nil
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -40,6 +40,8 @@ const (
 	joinTypeABP  = "ABP"
 )
 
+var noReadings = map[string]interface{}{"": "no readings available yet"}
+
 // Config defines the node's config.
 type Config struct {
 	JoinType    string   `json:"join_type,omitempty"`
@@ -303,7 +305,7 @@ func (n *Node) Readings(ctx context.Context, extra map[string]interface{}) (map[
 			if extra[data.FromDMString] == true {
 				return map[string]interface{}{}, data.ErrNoCaptureToStore
 			}
-			return map[string]interface{}{"": "no readings available yet"}, nil
+			return noReadings, nil
 		}
 		return reading.(map[string]interface{}), nil
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -343,7 +343,7 @@ func TestReadings(t *testing.T) {
 	// If lastReadings is empty and the call is not from data manager, return no error.
 	readings, err = n.Readings(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
+	test.That(t, readings, test.ShouldResemble, noReadings)
 
 	// If lastReadings is empty and the call is from data manager, return ErrNoCaptureToStore
 	_, err = n.Readings(ctx, map[string]interface{}{data.FromDMString: true})
@@ -352,5 +352,5 @@ func TestReadings(t *testing.T) {
 	// If data.FromDmString is false, return no error
 	_, err = n.Readings(context.Background(), map[string]interface{}{data.FromDMString: false})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
+	test.That(t, readings, test.ShouldResemble, noReadings)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -343,7 +343,7 @@ func TestReadings(t *testing.T) {
 	// If lastReadings is empty and the call is not from data manager, return no error.
 	readings, err = n.Readings(ctx, nil)
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{})
+	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
 
 	// If lastReadings is empty and the call is from data manager, return ErrNoCaptureToStore
 	_, err = n.Readings(ctx, map[string]interface{}{data.FromDMString: true})
@@ -352,5 +352,5 @@ func TestReadings(t *testing.T) {
 	// If data.FromDmString is false, return no error
 	_, err = n.Readings(context.Background(), map[string]interface{}{data.FromDMString: false})
 	test.That(t, err, test.ShouldBeNil)
-	test.That(t, readings, test.ShouldResemble, map[string]interface{}{})
+	test.That(t, readings, test.ShouldResemble, map[string]interface{}{"": "no readings available yet"})
 }


### PR DESCRIPTION
Due to the recent updates in the sensor server to check for nil returns, returning an empty map will result in the error `calling handler error rpc error: code = Unknown desc = sensor component tilt Readings should not return nil readings`. To avoid this I am instead returning an empty string in the readings map stating that there are no readings yet.

Tested manually and updated unit tests. 