### PR TITLE
RSDK-9811 leaked routine on module restart

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -110,6 +110,8 @@ type gateway struct {
 	started bool
 	rstPin  board.GPIOPin
 	pwrPin  board.GPIOPin
+
+	logReader *os.File
 }
 
 // NewGateway creates a new gateway
@@ -239,6 +241,7 @@ func (g *gateway) captureCOutputToLogs(ctx context.Context) {
 	C.disableBuffering()
 
 	stdoutR, stdoutW, err := os.Pipe()
+	g.logReader = stdoutR
 	if err != nil {
 		g.logger.Errorf("unable to create pipe for C logs")
 		return
@@ -489,6 +492,9 @@ func (g *gateway) Close(ctx context.Context) error {
 	}
 
 	if g.loggingWorker != nil {
+		if g.logReader != nil {
+			g.logReader.Close()
+		}
 		g.loggingWorker.Stop()
 		delete(loggingRoutineStarted, g.Name().Name)
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -493,9 +493,11 @@ func (g *gateway) Close(ctx context.Context) error {
 
 	if g.loggingWorker != nil {
 		if g.logReader != nil {
+			//nolint:errcheck
 			g.logReader.Close()
 		}
 		if g.logWriter != nil {
+			//nolint:errcheck
 			g.logWriter.Close()
 		}
 		g.loggingWorker.Stop()

--- a/gateway/join.go
+++ b/gateway/join.go
@@ -116,7 +116,7 @@ func (g *gateway) parseJoinRequestPacket(payload []byte) (joinRequest, *node.Nod
 	}
 
 	if matched.NodeName == "" {
-		g.logger.Debugf("received join requested with dev EUI %x - unknown device, ignoring", devEUIBE)
+		g.logger.Infof("received join request with dev EUI %x - unknown device, ignoring", devEUIBE)
 		return joinRequest, nil, errNoDevice
 	}
 


### PR DESCRIPTION
the logging goroutine leaks on restart due to the reader not being closed. Tested manually and didn't observe any leaks.