### PR TITLE
RSDK-9808 Persist OTAA data across restarts

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -470,7 +470,6 @@ func (g *gateway) searchForDeviceInFile(devEUI []byte) (*deviceInfo, error) {
 		}
 
 		if bytes.Equal(devEUI, savedEUI) {
-			g.logger.Warnf("found!")
 			// device found in the file
 			return &d, nil
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -391,9 +391,6 @@ func (g *gateway) DoCommand(ctx context.Context, cmd map[string]interface{}) (ma
 		return map[string]interface{}{"validate": 1}, nil
 	}
 
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
 	// Add the nodes to the list of devices.
 	if newNode, ok := cmd["register_device"]; ok {
 		if newN, ok := newNode.(map[string]interface{}); ok {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -65,6 +65,14 @@ type Config struct {
 	BoardName string `json:"board"`
 }
 
+// deviceInfo is a struct containing OTAA device information.
+// This info is saved across module restarts for each device.
+type deviceInfo struct {
+	DevEUI  string `json:"dev_eui"`
+	DevAddr string `json:"dev_addr"`
+	AppSKey string `json:"app_skey"`
+}
+
 func init() {
 	resource.RegisterComponent(
 		sensor.API,
@@ -114,8 +122,7 @@ type gateway struct {
 
 	logReader *os.File
 	logWriter *os.File
-
-	dataFile *os.File
+	dataFile  *os.File
 }
 
 // NewGateway creates a new gateway
@@ -133,8 +140,6 @@ func NewGateway(
 
 	moduleDataDir := os.Getenv("VIAM_MODULE_DATA")
 	filePath := filepath.Join(moduleDataDir, "devicedata.txt")
-
-	// open the file
 	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
 		return nil, err

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -387,6 +387,8 @@ func (g *gateway) updateReadings(name string, newReadings map[string]interface{}
 
 // DoCommand validates that the dependency is a gateway, and adds and removes nodes from the device maps.
 func (g *gateway) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
 	// Validate that the dependency is correct.
 	if _, ok := cmd["validate"]; ok {
 		return map[string]interface{}{"validate": 1}, nil
@@ -448,8 +450,6 @@ func (g *gateway) searchForDeviceInFile(devEUI []byte) (*deviceInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read device info from file: %w", err)
 	}
-
-	g.logger.Warnf("HERE: saved devices %s", savedDevices)
 	// Check if the dev EUI is in the file.
 	for _, d := range savedDevices {
 		savedEUI, err := hex.DecodeString(d.DevEUI)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"gateway/node"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -447,7 +448,7 @@ func (g *gateway) searchForDeviceInFile(devEUI []byte) (*deviceInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read device info from file: %w", err)
 	}
-	// Check if the devAddr is in the file.
+	// Check if the dev EUI is in the file.
 	for _, d := range savedDevices {
 		savedEUI, err := hex.DecodeString(d.DevEUI)
 		if err != nil {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -127,12 +127,16 @@ func NewGateway(
 		logger:  logger,
 		started: false,
 	}
+
 	moduleDataDir := os.Getenv("VIAM_MODULE_DATA")
 	filePath := filepath.Join(moduleDataDir, "devicedata.txt")
-	file, err := os.Create(filePath)
+
+	// open the file
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, err
 	}
+
 	g.dataFile = file
 
 	err = g.Reconfigure(ctx, deps, conf)
@@ -504,6 +508,9 @@ func (g *gateway) Close(ctx context.Context) error {
 		g.loggingWorker.Stop()
 		delete(loggingRoutineStarted, g.Name().Name)
 	}
+
+	//nolint:errcheck
+	g.dataFile.Close()
 
 	return nil
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -139,6 +139,7 @@ func NewGateway(
 		started: false,
 	}
 
+	// Create or open the file used to save device data across restarts.
 	moduleDataDir := os.Getenv("VIAM_MODULE_DATA")
 	filePath := filepath.Join(moduleDataDir, "devicedata.txt")
 	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o666)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -420,11 +420,14 @@ func (g *gateway) DoCommand(ctx context.Context, cmd map[string]interface{}) (ma
 				if !errors.Is(err, errNoDevice) {
 					return nil, fmt.Errorf("error while searching for device in file: %w", err)
 				}
+
 			}
-			// device was found in the file, update the gateway's device map with the device info.
-			err = g.updateDeviceInfo(mergedNode, deviceInfo)
-			if err != nil {
-				return nil, fmt.Errorf("error while updating device info: %w", err)
+			if deviceInfo != nil {
+				// device was found in the file, update the gateway's device map with the device info.
+				err = g.updateDeviceInfo(mergedNode, deviceInfo)
+				if err != nil {
+					return nil, fmt.Errorf("error while updating device info: %w", err)
+				}
 			}
 		}
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -507,19 +507,25 @@ func (g *gateway) Close(ctx context.Context) error {
 
 	if g.loggingWorker != nil {
 		if g.logReader != nil {
-			//nolint:errcheck
-			g.logReader.Close()
+
+			if err := g.logReader.Close(); err != nil {
+				g.logger.Errorf("error closing log reader: %s", err)
+			}
 		}
 		if g.logWriter != nil {
-			//nolint:errcheck
-			g.logWriter.Close()
+			if err := g.logWriter.Close(); err != nil {
+				g.logger.Errorf("error closing log writer: %s", err)
+			}
 		}
 		g.loggingWorker.Stop()
 		delete(loggingRoutineStarted, g.Name().Name)
 	}
 
-	//nolint:errcheck
-	g.dataFile.Close()
+	if g.dataFile != nil {
+		if err := g.dataFile.Close(); err != nil {
+			g.logger.Errorf("error closing data file: %s", err)
+		}
+	}
 
 	return nil
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -159,9 +159,11 @@ func TestDoCommand(t *testing.T) {
 	test.That(t, dev.DecoderPath, test.ShouldResemble, "/newpath")
 
 	// Test that if device is in file, OTAA fields get populated
+	// clear map and device otaa info for the new test
 	dev = g.devices[testNodeName]
-	// clear map for the new test
 	g.devices = map[string]*node.Node{}
+	dev.AppSKey = nil
+	dev.Addr = nil
 	registerCmd["register_device"] = dev
 	doOverWire(s, registerCmd)
 	test.That(t, len(g.devices), test.ShouldEqual, 1)

--- a/gateway/join.go
+++ b/gateway/join.go
@@ -245,7 +245,7 @@ func (g *gateway) generateJoinAccept(ctx context.Context, jr joinRequest, d *nod
 // The file will later be updated with the info from the new join procedure.
 func searchAndRemove(file *os.File, devEUI []byte) error {
 	// Read the device info from the file
-	devices, err := readDeviceInfoFromFile(file)
+	devices, err := readFromFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to read device info from file: %w", err)
 	}
@@ -345,7 +345,7 @@ func reverseByteArray(arr []byte) []byte {
 
 func removeDeviceInfoFromFile(file *os.File, devToRemove deviceInfo) error {
 	// Read the existing data from the file
-	devices, err := readDeviceInfoFromFile(file)
+	devices, err := readFromFile(file)
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func removeDeviceInfoFromFile(file *os.File, devToRemove deviceInfo) error {
 // Function to write the device info from the persitent data file.
 func addDeviceInfoToFile(file *os.File, newDevice deviceInfo) error {
 	// Read the existing data from the file
-	devices, err := readDeviceInfoFromFile(file)
+	devices, err := readFromFile(file)
 	if err != nil {
 		return err
 	}
@@ -417,7 +417,7 @@ func writeToFile(file *os.File, devices []deviceInfo) error {
 }
 
 // Function to read the device info from the persitent data file.
-func readDeviceInfoFromFile(file *os.File) ([]deviceInfo, error) {
+func readFromFile(file *os.File) ([]deviceInfo, error) {
 	// Reset file pointer to the beginning
 	_, err := file.Seek(0, io.SeekStart)
 	if err != nil {

--- a/gateway/join_test.go
+++ b/gateway/join_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"gateway/node"
 	"os"
-	"path/filepath"
 	"testing"
+
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.viam.com/rdk/logging"
@@ -27,15 +27,6 @@ var (
 	// Unknown device for testing error cases.
 	unknownDevEUI = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 )
-
-func createDataFile(t *testing.T) *os.File {
-	// Create a temp device data file for testing
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "devices.txt")
-	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o644)
-	test.That(t, err, test.ShouldBeNil)
-	return file
-}
 
 func TestReverseByteArray(t *testing.T) {
 	tests := []struct {
@@ -241,7 +232,7 @@ func TestGenerateJoinAccept(t *testing.T) {
 			test.That(t, len(tt.device.AppSKey), test.ShouldEqual, 16) // AppSKey should be generated
 
 			if tt.checkFile {
-				devices, err := readDeviceInfoFromFile(g.dataFile)
+				devices, err := readFromFile(g.dataFile)
 				test.That(t, err, test.ShouldBeNil)
 				test.That(t, len(devices), test.ShouldEqual, tt.expectedFileLen)
 				// Find the device in the file
@@ -273,7 +264,7 @@ func TestAddAndRemoveDeviceInfo(t *testing.T) {
 	err = addDeviceInfoToFile(file, info2)
 	test.That(t, err, test.ShouldBeNil)
 
-	deviceInfo, err := readDeviceInfoFromFile(file)
+	deviceInfo, err := readFromFile(file)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(deviceInfo), test.ShouldEqual, 2)
 	test.That(t, deviceInfo[0].DevEUI, test.ShouldEqual, fmt.Sprintf("%X", testDevEUI))
@@ -283,7 +274,7 @@ func TestAddAndRemoveDeviceInfo(t *testing.T) {
 	err = removeDeviceInfoFromFile(file, info)
 	test.That(t, err, test.ShouldBeNil)
 
-	newDeviceInfo, err := readDeviceInfoFromFile(file)
+	newDeviceInfo, err := readFromFile(file)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(newDeviceInfo), test.ShouldEqual, 1)
 	test.That(t, newDeviceInfo[0].DevEUI, test.ShouldEqual, fmt.Sprintf("%X", testDevEUILE))

--- a/gateway/join_test.go
+++ b/gateway/join_test.go
@@ -208,10 +208,10 @@ func TestGenerateJoinAccept(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 }
 
-func TestReadAndWriteDeviceInfoToFile(t *testing.T) {
+func TestAddAndRemoveDeviceInfoToFile(t *testing.T) {
 	file := createDataFile(t)
-	deviceInfos := []deviceInfo{{DevEUI: fmt.Sprintf("%X", testDevEUI), DevAddr: "123456", AppSKey: fmt.Sprintf("%X", testAppSKey)}}
-	err := writeDeviceInfoToFile(file, deviceInfos)
+	info := deviceInfo{DevEUI: fmt.Sprintf("%X", testDevEUI), DevAddr: "123456", AppSKey: fmt.Sprintf("%X", testAppSKey)}
+	err := addDeviceInfoToFile(file, info)
 	test.That(t, err, test.ShouldBeNil)
 
 	deviceInfo, err := readDeviceInfoFromFile(file)

--- a/gateway/join_test.go
+++ b/gateway/join_test.go
@@ -150,6 +150,10 @@ func TestParseJoinRequestPacket(t *testing.T) {
 
 	_, _, err = g.parseJoinRequestPacket(unknownPayload)
 	test.That(t, err, test.ShouldEqual, errNoDevice)
+
+	err = g.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
+
 }
 
 func TestGenerateJoinAccept(t *testing.T) {

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -7,11 +7,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"gateway/node"
 	"os"
 	"reflect"
 	"time"
 
+	"gateway/node"
 	"github.com/robertkrimen/otto"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -112,9 +112,9 @@ func (g *gateway) findDevice(devAddr []byte) (*node.Node, error) {
 		return dev, nil
 	}
 	return device, nil
-
 }
 
+// searchForDeviceInfoInFile searhces for device address match in the module's data file and returns the device info.
 func (g *gateway) searchForDeviceInFile(packetDevAddr []byte) (*deviceInfo, error) {
 	// read all the saved devices from the file
 	savedDevices, err := readDeviceInfoFromFile(g.dataFile)
@@ -136,6 +136,7 @@ func (g *gateway) searchForDeviceInFile(packetDevAddr []byte) (*deviceInfo, erro
 	return nil, errNoDevice
 }
 
+// updateDeviceInfo adds the device info from the file into the gateway's device map.
 func (g *gateway) updateDeviceInfo(d *deviceInfo) (*node.Node, error) {
 	eui, err := hex.DecodeString(d.DevEUI)
 	if err != nil {

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -36,7 +36,6 @@ func (g *gateway) parseDataUplink(ctx context.Context, phyPayload []byte) (strin
 				// deviceInfo matching device was not found, this is an unknown device.
 				g.logger.Infof("received packet from unknown device, ignoring")
 				return "", map[string]interface{}{}, errNoDevice
-
 			}
 			return "", map[string]interface{}{}, fmt.Errorf("error while searching for device in file: %w", err)
 		}
@@ -186,13 +185,13 @@ func matchDeviceAddr(devAddr []byte, devices map[string]*node.Node) (*node.Node,
 	return nil, fmt.Errorf("no match for DeviceAddress %v", devAddr)
 }
 
-func matchDeviceEUI(EUI []byte, devices map[string]*node.Node) (*node.Node, error) {
+func matchDeviceEUI(eui []byte, devices map[string]*node.Node) (*node.Node, error) {
 	for _, dev := range devices {
-		if bytes.Equal(EUI, dev.DevEui) {
+		if bytes.Equal(eui, dev.DevEui) {
 			return dev, nil
 		}
 	}
-	return nil, fmt.Errorf("no match for Dev EUI %v", EUI)
+	return nil, fmt.Errorf("no match for Dev EUI %v", eui)
 }
 
 func decodePayload(ctx context.Context, fPort uint8, path string, data []byte) (map[string]interface{}, error) {

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
 	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
@@ -223,7 +224,7 @@ func TestSearchForDeviceInFile(t *testing.T) {
 	//  Device not found in file should return nil and no error
 	unknownAddr := []byte{0x01, 0x02, 0x03, 0x04}
 	device, err = g.searchForDeviceInFile(unknownAddr)
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, err, test.ShouldBeError, errNoDevice)
 	test.That(t, device, test.ShouldBeNil)
 
 	// Test File read error

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -136,7 +136,9 @@ func TestParseDataUplink(t *testing.T) {
 	_, _, err = g.parseDataUplink(context.Background(), createUnknownDevicePayload())
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeError, errNoDevice)
-	g.Close(context.Background())
+
+	err = g.Close(context.Background())
+	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestConvertTo32Bit(t *testing.T) {

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -2,6 +2,10 @@ package gateway
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"gateway/node"
@@ -47,6 +51,12 @@ var (
 
 // setupTestGateway creates a test gateway with a configured test device.
 func setupTestGateway(t *testing.T) *gateway {
+	// Create a temp device data file for testing
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "devices.txt")
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)
+	test.That(t, err, test.ShouldBeNil)
+
 	testDevices := make(map[string]*node.Node)
 	testNode := &node.Node{
 		Addr:        testDeviceAddr,
@@ -54,12 +64,52 @@ func setupTestGateway(t *testing.T) *gateway {
 		NodeName:    testNodeName,
 		DecoderPath: testDecoderPath,
 		JoinType:    "OTAA",
+		DevEui:      testDevEUI,
 	}
 	testDevices[testNodeName] = testNode
 
 	return &gateway{
-		logger:  logging.NewTestLogger(t),
-		devices: testDevices,
+		logger:   logging.NewTestLogger(t),
+		devices:  testDevices,
+		dataFile: file,
+	}
+}
+
+// setupTestGatewayWithFileDevice creates a test gateway with device info only in file.
+func setupFileTest(t *testing.T) *gateway {
+	// Create a temp device data file for testing
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "devices.txt")
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Write device info to file
+	devices := []deviceInfo{
+		{
+			DevEUI:  "0102030405060708", // matches testNode.DevEui
+			DevAddr: fmt.Sprintf("%X", testDeviceAddr),
+			AppSKey: fmt.Sprintf("%X", testAppSKey),
+		},
+	}
+	data, err := json.MarshalIndent(devices, "", "  ")
+	test.That(t, err, test.ShouldBeNil)
+	_, err = file.Write(data)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Create gateway with empty devices map but device info in file
+	testDevices := make(map[string]*node.Node)
+	testNode := &node.Node{
+		NodeName:    testNodeName,
+		DecoderPath: testDecoderPath,
+		JoinType:    "OTAA",
+		DevEui:      testDevEUI,
+	}
+	testDevices[testNodeName] = testNode
+
+	return &gateway{
+		logger:   logging.NewTestLogger(t),
+		devices:  testDevices,
+		dataFile: file,
 	}
 }
 
@@ -132,6 +182,91 @@ func TestParseDataUplink(t *testing.T) {
 	_, _, err = g.parseDataUplink(context.Background(), createUnknownDevicePayload())
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeError, errNoDevice)
+	g.Close(context.Background())
+
+	// Test that a device that is not in the device map but is in the persistent data file is added to the device map.
+	g = setupFileTest(t)
+	deviceName, readings, err = g.parseDataUplink(context.Background(), validUplinkData)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, readings, test.ShouldNotBeNil)
+	test.That(t, deviceName, test.ShouldEqual, testNodeName)
+
+	// Verify device info was updated in device map
+	device, ok := g.devices[testNodeName]
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, device.Addr, test.ShouldResemble, testDeviceAddr)
+	test.That(t, len(device.AppSKey), test.ShouldEqual, 16)
+	test.That(t, device.AppSKey, test.ShouldResemble, testAppSKey)
+
+	g.Close(context.Background())
+
+}
+
+func TestSearchForDeviceInFile(t *testing.T) {
+	g := setupTestGateway(t)
+
+	// Device found in file should return device info and no error
+	devices := []deviceInfo{
+		{
+			DevEUI:  "0102030405060708",
+			DevAddr: fmt.Sprintf("%X", testDeviceAddr),
+			AppSKey: "5572404C694E6B4C6F526132303138323",
+		},
+	}
+	data, err := json.MarshalIndent(devices, "", "  ")
+	test.That(t, err, test.ShouldBeNil)
+	_, err = g.dataFile.Write(data)
+	test.That(t, err, test.ShouldBeNil)
+
+	device, err := g.searchForDeviceInFile(testDeviceAddr)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, device, test.ShouldNotBeNil)
+	test.That(t, device.DevAddr, test.ShouldEqual, testDeviceAddr)
+
+	//  Device not found in file should return nil and no error
+	unknownAddr := []byte{0x01, 0x02, 0x03, 0x04}
+	device, err = g.searchForDeviceInFile(unknownAddr)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, device, test.ShouldBeNil)
+
+	// Test File read error
+	g.dataFile.Close()
+	_, err = g.searchForDeviceInFile(testDeviceAddr)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "failed to read device info from file")
+}
+
+func TestUpdateDeviceInfo(t *testing.T) {
+	g := setupTestGateway(t)
+
+	newAppSKey := []byte{
+		0x55, 0x72, 0x40, 0x4C,
+		0x69, 0x6E, 0x6B, 0x4C,
+		0x6F, 0x52, 0x61, 0x32,
+		0x31, 0x30, 0x32, 0x23,
+	}
+
+	newDevAddr := []byte{0xe2, 0x73, 0x65, 0x67}
+
+	// Test 1: Successful update
+	validInfo := &deviceInfo{
+		DevEUI:  fmt.Sprintf("%X", testDevEUI), // matches dev EUI on the gateway map
+		DevAddr: fmt.Sprintf("%X", newDevAddr),
+		AppSKey: fmt.Sprintf("%X", newAppSKey),
+	}
+
+	device, err := g.updateDeviceInfo(validInfo)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, device, test.ShouldNotBeNil)
+	test.That(t, device.NodeName, test.ShouldEqual, testNodeName)
+	test.That(t, device.AppSKey, test.ShouldResemble, newAppSKey)
+	test.That(t, device.Addr, test.ShouldResemble, newDevAddr)
+
+	// Device not found in map
+	g.devices = make(map[string]*node.Node) // clear devices map
+	_, err = g.updateDeviceInfo(validInfo)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "could not find the matching device in device map")
 }
 
 func TestConvertTo32Bit(t *testing.T) {

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -2,15 +2,35 @@ package gateway
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-	"testing"
-
 	"gateway/node"
+	"testing"
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
+
+// setupTestGateway creates a test gateway with a configured test device.
+func setupUplinkGateway(t *testing.T) *gateway {
+	//Create a temp device data file for testing
+	file := createDataFile(t)
+
+	testDevices := make(map[string]*node.Node)
+	testNode := &node.Node{
+		Addr:        testDeviceAddr,
+		AppSKey:     testAppSKey,
+		NodeName:    testNodeName,
+		DecoderPath: testDecoderPath,
+		JoinType:    "OTAA",
+		DevEui:      testDevEUI,
+	}
+	testDevices[testNodeName] = testNode
+
+	return &gateway{
+		logger:   logging.NewTestLogger(t),
+		devices:  testDevices,
+		dataFile: file,
+	}
+}
 
 var (
 	// Test device configuration.
@@ -46,32 +66,6 @@ var (
 	expectedHumidity = 460.8
 	expectedCurrent  = 0.0
 )
-
-// setupTestGateway creates a test gateway with a configured test device.
-func setupTestGateway(t *testing.T) *gateway {
-	// Create a temp device data file for testing
-	tmpDir := t.TempDir()
-	filePath := filepath.Join(tmpDir, "devices.txt")
-	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o644)
-	test.That(t, err, test.ShouldBeNil)
-
-	testDevices := make(map[string]*node.Node)
-	testNode := &node.Node{
-		Addr:        testDeviceAddr,
-		AppSKey:     testAppSKey,
-		NodeName:    testNodeName,
-		DecoderPath: testDecoderPath,
-		JoinType:    "OTAA",
-		DevEui:      testDevEUI,
-	}
-	testDevices[testNodeName] = testNode
-
-	return &gateway{
-		logger:   logging.NewTestLogger(t),
-		devices:  testDevices,
-		dataFile: file,
-	}
-}
 
 // createInvalidPayload creates an invalid payload for testing error cases.
 func createInvalidPayload() []byte {
@@ -112,7 +106,7 @@ func createUnknownDevicePayload() []byte {
 }
 
 func TestParseDataUplink(t *testing.T) {
-	g := setupTestGateway(t)
+	g := setupUplinkGateway(t)
 
 	// Test valid data uplink
 	deviceName, readings, err := g.parseDataUplink(context.Background(), validUplinkData)

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"gateway/node"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"gateway/node"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/test"
 )
@@ -203,7 +203,7 @@ func TestParseDataUplink(t *testing.T) {
 func TestSearchForDeviceInFile(t *testing.T) {
 	g := setupTestGateway(t)
 
-	// Device found in file should return device info and no error
+	// Device found in file should return device info
 	devices := []deviceInfo{
 		{
 			DevEUI:  "0102030405060708",
@@ -221,7 +221,7 @@ func TestSearchForDeviceInFile(t *testing.T) {
 	test.That(t, device, test.ShouldNotBeNil)
 	test.That(t, device.DevAddr, test.ShouldEqual, fmt.Sprintf("%X", testDeviceAddr))
 
-	//  Device not found in file should return nil and no error
+	//  Device not found in file should return errNoDevice
 	unknownAddr := []byte{0x01, 0x02, 0x03, 0x04}
 	device, err = g.searchForDeviceInFile(unknownAddr)
 	test.That(t, err, test.ShouldBeError, errNoDevice)
@@ -260,7 +260,7 @@ func TestUpdateDeviceInfo(t *testing.T) {
 	test.That(t, device.AppSKey, test.ShouldResemble, newAppSKey)
 	test.That(t, device.Addr, test.ShouldResemble, newDevAddr)
 
-	// Device not found in map
+	// If the device is not found in the map should return error
 	g.devices = make(map[string]*node.Node) // clear devices map
 	_, err = g.updateDeviceInfo(validInfo)
 	test.That(t, err, test.ShouldNotBeNil)


### PR DESCRIPTION
Currently, if the module is restarted the dev addr and keys will be lost and the device needs to resend a join request. This PR writes the OTAA info of each device to a file during the join procedure. When a previously known device is registered to the gateway through the docommand, the device's info is pulled from the file and added to the device object. Now the device does not need to be manually reset if the module gets restarted.

Testing: Added unit tests for each function, tested manually using tilt sensor.

To do:
[ ] more manual testing