### PR TITLE
RSDK-9814 Increase packet buffer size to 10

### DIFF
--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -109,7 +109,7 @@ struct lgw_pkt_rx_s* createRxPacketArray() {
 }
 
 int receive(struct lgw_pkt_rx_s* packet)  {
-    return lgw_receive(8, packet);
+    return lgw_receive(MAX_RX_PKT, packet);
 }
 
 int send(struct lgw_pkt_tx_s* packet) {

--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -7,8 +7,7 @@
 
 #define RADIO_0_FREQ     902700000
 #define RADIO_1_FREQ     903700000
-
-const int MAX_RX_PKT = 10;  // Declare MAX_RX_PKT as an int so it can be used in go
+int MAX_RX_PKT = 10;
 
 // the IF chain frequencies allow the gateway to read on multiple frequency channels.
 // subtracting main frequenecy - intermediate frequency will give that channel's freq.

--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -5,10 +5,10 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#define MAX_RX_PKT 8
-
 #define RADIO_0_FREQ     902700000
 #define RADIO_1_FREQ     903700000
+
+const int MAX_RX_PKT = 10;  // Declare MAX_RX_PKT as an int so it can be used in go
 
 // the IF chain frequencies allow the gateway to read on multiple frequency channels.
 // subtracting main frequenecy - intermediate frequency will give that channel's freq.
@@ -109,7 +109,7 @@ struct lgw_pkt_rx_s* createRxPacketArray() {
 }
 
 int receive(struct lgw_pkt_rx_s* packet)  {
-    return lgw_receive(1, packet);
+    return lgw_receive(8, packet);
 }
 
 int send(struct lgw_pkt_tx_s* packet) {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -316,7 +316,9 @@ func (g *gateway) receivePackets(ctx context.Context) {
 				for j := range int(packets[i].size) {
 					payload = append(payload, byte(packets[i].payload[j]))
 				}
-				g.handlePacket(ctx, payload)
+				if payload != nil {
+					g.handlePacket(ctx, payload)
+				}
 			}
 		}
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -293,8 +293,6 @@ func (g *gateway) receivePackets(ctx context.Context) {
 		}
 		numPackets := int(C.receive(p))
 		maxRxPkt := int(C.MAX_RX_PKT)
-		// convert from c array to go slice
-		packets := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), maxRxPkt)
 
 		switch numPackets {
 		case 0:
@@ -307,6 +305,8 @@ func (g *gateway) receivePackets(ctx context.Context) {
 		case -1:
 			g.logger.Errorf("error receiving lora packet")
 		default:
+			// convert from c array to go slice
+			packets := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), maxRxPkt)
 			for i := range numPackets {
 				// received a LORA packet
 				var payload []byte

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -292,7 +292,6 @@ func (g *gateway) receivePackets(ctx context.Context) {
 		default:
 		}
 		numPackets := int(C.receive(p))
-		maxRxPkt := int(C.MAX_RX_PKT)
 
 		switch numPackets {
 		case 0:
@@ -306,7 +305,7 @@ func (g *gateway) receivePackets(ctx context.Context) {
 			g.logger.Errorf("error receiving lora packet")
 		default:
 			// convert from c array to go slice
-			packets := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), maxRxPkt)
+			packets := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), int(C.MAX_RX_PKT))
 			for i := range numPackets {
 				// received a LORA packet
 				var payload []byte

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -294,7 +294,7 @@ func (g *gateway) receivePackets(ctx context.Context) {
 		// convert from c array to go slice
 		numPackets := int(C.receive(p))
 		maxRxPkt := int(C.MAX_RX_PKT)
-		packet := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), maxRxPkt)
+		packets := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), maxRxPkt)
 
 		switch numPackets {
 		case 0:
@@ -307,15 +307,15 @@ func (g *gateway) receivePackets(ctx context.Context) {
 		case -1:
 			g.logger.Errorf("error receiving lora packet")
 		default:
-			for i := 0; i < numPackets; i++ {
+			for i := range numPackets {
 				// received a LORA packet
 				var payload []byte
-				if packet[i].size == 0 {
+				if packets[i].size == 0 {
 					continue
 				}
 				// Convert packet to go byte array
-				for j := range int(packet[i].size) {
-					payload = append(payload, byte(packet[i].payload[j]))
+				for j := range int(packets[i].size) {
+					payload = append(payload, byte(packets[i].payload[j]))
 				}
 				g.handlePacket(ctx, payload)
 			}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -291,9 +291,9 @@ func (g *gateway) receivePackets(ctx context.Context) {
 			return
 		default:
 		}
-		// convert from c array to go slice
 		numPackets := int(C.receive(p))
 		maxRxPkt := int(C.MAX_RX_PKT)
+		// convert from c array to go slice
 		packets := unsafe.Slice((*C.struct_lgw_pkt_rx_s)(unsafe.Pointer(p)), maxRxPkt)
 
 		switch numPackets {

--- a/gateway/gateway.h
+++ b/gateway/gateway.h
@@ -10,3 +10,4 @@ int stopGateway();
 int setUpGateway(int com_path);
 void disableBuffering();
 void redirectToPipe(int fd);
+int MAX_RX_PKT;

--- a/gateway/gateway.h
+++ b/gateway/gateway.h
@@ -10,4 +10,5 @@ int stopGateway();
 int setUpGateway(int com_path);
 void disableBuffering();
 void redirectToPipe(int fd);
-int MAX_RX_PKT;
+extern const int MAX_RX_PKT;
+


### PR DESCRIPTION
When debug was on in the gateway, the line `WARNING: not enough space allocated, fetched 2 packet(s), 1 will be left in RX buffer` showed occasionally. Increased the buffer to 10 to ensure we don't miss any packets, no longer see the warning when manually testing.