### PR TITLE
RSDK-10107 Use accurate sleep and ignore duplicate packets

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -8,6 +8,7 @@ package gateway
 #include "../sx1302/libloragw/inc/loragw_hal.h"
 #include "gateway.h"
 #include <stdlib.h>
+#include <string.h>
 */
 import "C"
 
@@ -18,6 +19,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -334,6 +336,14 @@ func (g *gateway) receivePackets(ctx context.Context) {
 				if packets[i].size == 0 {
 					continue
 				}
+
+				// don't process duplicates
+				if numPackets > 1 && i > 0 {
+					if isSamePacket(packets[i-1], packets[i]) {
+						g.logger.Debugf("skipped duplicate packet")
+						continue
+					}
+				}
 				// Convert packet to go byte array
 				for j := range int(packets[i].size) {
 					payload = append(payload, byte(packets[i].payload[j]))
@@ -352,7 +362,7 @@ func (g *gateway) handlePacket(ctx context.Context, payload []byte) {
 		switch payload[0] {
 		case 0x0:
 			g.logger.Debugf("received join request")
-			err := g.handleJoin(ctx, payload)
+			err := g.handleJoin(ctx, payload, time.Now())
 			if err != nil {
 				// don't log as error if it was a request from unknown device.
 				if errors.Is(errNoDevice, err) {
@@ -467,6 +477,23 @@ func (g *gateway) DoCommand(ctx context.Context, cmd map[string]interface{}) (ma
 	}
 
 	return map[string]interface{}{}, nil
+}
+
+// Criterias to determine if packets are identical:
+//
+//	-- count_us should be equal or can have up to 24µs of difference (3 samples)
+//	-- freq should be same
+//	-- datarate should be same
+//	-- payload should be same
+func isSamePacket(p1, p2 C.struct_lgw_pkt_rx_s) bool {
+	if math.Abs(float64(p1.count_us-p2.count_us)) <= 24 &&
+		p1.freq_hz == p2.freq_hz &&
+		p1.datarate == p2.datarate &&
+		C.memcmp(unsafe.Pointer(&p1.payload[0]), unsafe.Pointer(&p2.payload[0]), C.size_t(len(p1.payload))) == 0 {
+		return true
+	}
+	return false
+
 }
 
 // searchForDeviceInfoInFile searhces for device address match in the module's data file and returns the device info.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -479,7 +479,7 @@ func (g *gateway) DoCommand(ctx context.Context, cmd map[string]interface{}) (ma
 	return map[string]interface{}{}, nil
 }
 
-// Criterias to determine if packets are identical:
+// Criteria to determine if packets are identical:
 //
 //	-- count_us should be equal or can have up to 24µs of difference (3 samples)
 //	-- freq should be same
@@ -489,11 +489,11 @@ func isSamePacket(p1, p2 C.struct_lgw_pkt_rx_s) bool {
 	if math.Abs(float64(p1.count_us-p2.count_us)) <= 24 &&
 		p1.freq_hz == p2.freq_hz &&
 		p1.datarate == p2.datarate &&
+		//nolint:gocritic
 		C.memcmp(unsafe.Pointer(&p1.payload[0]), unsafe.Pointer(&p2.payload[0]), C.size_t(len(p1.payload))) == 0 {
 		return true
 	}
 	return false
-
 }
 
 // searchForDeviceInfoInFile searhces for device address match in the module's data file and returns the device info.

--- a/gateway/join.go
+++ b/gateway/join.go
@@ -61,6 +61,7 @@ func (g *gateway) handleJoin(ctx context.Context, payload []byte, t time.Time) e
 
 	g.logger.Infof("sending join accept to %s", device.NodeName)
 
+	// TODO: Move this to generic downlink function
 	txPkt := C.struct_lgw_pkt_tx_s{
 		freq_hz:    C.uint32_t(rx2Frequenecy),
 		tx_mode:    C.uint8_t(0), // immediate mode
@@ -82,7 +83,9 @@ func (g *gateway) handleJoin(ctx context.Context, payload []byte, t time.Time) e
 
 	// send on rx2 window - opens 6 seconds after join request.
 	waitDuration := (joinRx2WindowSec * time.Second) - (time.Since(t))
-	accurateSleep(ctx, waitDuration)
+	if !accurateSleep(ctx, waitDuration) {
+		return fmt.Errorf("failed to send join accept: %w:", ctx.Err())
+	}
 
 	// lock so there is not two sends at the same time.
 	g.mu.Lock()

--- a/gateway/join.go
+++ b/gateway/join.go
@@ -84,7 +84,7 @@ func (g *gateway) handleJoin(ctx context.Context, payload []byte, t time.Time) e
 	// send on rx2 window - opens 6 seconds after join request.
 	waitDuration := (joinRx2WindowSec * time.Second) - (time.Since(t))
 	if !accurateSleep(ctx, waitDuration) {
-		return fmt.Errorf("failed to send join accept: %w:", ctx.Err())
+		return fmt.Errorf("failed to send join accept: %w", ctx.Err())
 	}
 
 	// lock so there is not two sends at the same time.

--- a/gateway/join_test.go
+++ b/gateway/join_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/viam-modules/gateway/node"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
@@ -391,7 +392,7 @@ func TestHandleJoin(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 
-	err = g.handleJoin(ctx, payload)
+	err = g.handleJoin(ctx, payload, time.Now())
 	test.That(t, err, test.ShouldBeNil)
 
 	// Test with unknown device
@@ -401,7 +402,7 @@ func TestHandleJoin(t *testing.T) {
 	unknownPayload = append(unknownPayload, testDevNonce...)
 	unknownPayload = append(unknownPayload, mic[:]...)
 
-	err = g.handleJoin(ctx, unknownPayload)
+	err = g.handleJoin(ctx, unknownPayload, time.Now())
 	test.That(t, err, test.ShouldEqual, errNoDevice)
 
 	err = g.Close(ctx)

--- a/gateway/join_test.go
+++ b/gateway/join_test.go
@@ -388,12 +388,12 @@ func TestHandleJoin(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	payload = append(payload, mic[:]...)
 
-	// Test with context that will timeout before rx2 window
-	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	// Test with context that will timeout before interacting with the hardware.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	err = g.handleJoin(ctx, payload, time.Now())
-	test.That(t, err, test.ShouldBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "context deadline exceeded")
 
 	// Test with unknown device
 	unknownPayload := []byte{0x00} // MHDR


### PR DESCRIPTION
Because there is only a 20 microsecond allowance for the rx delays, we should use accurate sleep to ensure the join accept makes it in time for the device's RX window. Additionally, filtering out duplicate packets we receive. 