### PR TITLE
RSDK-10089 allow decoder_path attribute to be link

### DIFF
--- a/draginolht65n/sensor.go
+++ b/draginolht65n/sensor.go
@@ -49,17 +49,16 @@ func (conf *Config) getNodeConfig() node.Config {
 	filePath := filepath.Join(moduleDataDir, decoderFilename)
 
 	return node.Config{
-		JoinType:    conf.JoinType,
-		Interval:    conf.Interval,
-		DecoderPath: filePath,
-		DevEUI:      conf.DevEUI,
-		AppKey:      conf.AppKey,
-		AppSKey:     conf.AppSKey,
-		NwkSKey:     conf.NwkSKey,
-		DevAddr:     conf.DevAddr,
-		Gateways:    conf.Gateways,
+		JoinType: conf.JoinType,
+		Interval: conf.Interval,
+		Decoder:  filePath,
+		DevEUI:   conf.DevEUI,
+		AppKey:   conf.AppKey,
+		AppSKey:  conf.AppSKey,
+		NwkSKey:  conf.NwkSKey,
+		DevAddr:  conf.DevAddr,
+		Gateways: conf.Gateways,
 	}
-
 }
 
 // Validate ensures all parts of the config are valid.
@@ -76,9 +75,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 type LHT65N struct {
 	resource.Named
 	logger logging.Logger
-
-	node        node.Node
-	decoderPath string
+	node   node.Node
 }
 
 func newLHT65N(

--- a/draginolht65n/sensor.go
+++ b/draginolht65n/sensor.go
@@ -3,8 +3,6 @@ package draginolht65n
 
 import (
 	"context"
-	"net/http"
-	"time"
 
 	"github.com/viam-modules/gateway/node"
 	"go.viam.com/rdk/components/sensor"
@@ -45,7 +43,7 @@ func init() {
 func (conf *Config) getNodeConfig(decoderFilePath string) node.Config {
 	return node.Config{
 		JoinType:    conf.JoinType,
-		DecoderPath: decoderFilePath,
+		DecoderPath: decoderURL,
 		Interval:    conf.Interval,
 		DevEUI:      conf.DevEUI,
 		AppKey:      conf.AppKey,
@@ -81,22 +79,13 @@ func newLHT65N(
 	conf resource.Config,
 	logger logging.Logger,
 ) (sensor.Sensor, error) {
-	httpClient := &http.Client{
-		Timeout: time.Second * 25,
-	}
-	decoderFilePath, err := node.WriteDecoderFileFromURL(ctx, decoderFilename, decoderURL, httpClient, logger)
-	if err != nil {
-		return nil, err
-	}
-
 	n := &LHT65N{
-		Named:       conf.ResourceName().AsNamed(),
-		logger:      logger,
-		node:        node.NewSensor(conf, logger),
-		decoderPath: decoderFilePath,
+		Named:  conf.ResourceName().AsNamed(),
+		logger: logger,
+		node:   node.NewSensor(conf, logger),
 	}
 
-	err = n.Reconfigure(ctx, deps, conf)
+	err := n.Reconfigure(ctx, deps, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/draginolht65n/sensor.go
+++ b/draginolht65n/sensor.go
@@ -40,7 +40,7 @@ func init() {
 		})
 }
 
-func (conf *Config) getNodeConfig(decoderFilePath string) node.Config {
+func (conf *Config) getNodeConfig() node.Config {
 	return node.Config{
 		JoinType:    conf.JoinType,
 		DecoderPath: decoderURL,
@@ -56,7 +56,7 @@ func (conf *Config) getNodeConfig(decoderFilePath string) node.Config {
 
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
-	nodeConf := conf.getNodeConfig("fixed")
+	nodeConf := conf.getNodeConfig()
 	deps, err := nodeConf.Validate(path)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (n *LHT65N) Reconfigure(ctx context.Context, deps resource.Dependencies, co
 		return err
 	}
 
-	nodeCfg := cfg.getNodeConfig(n.decoderPath)
+	nodeCfg := cfg.getNodeConfig()
 
 	err = n.node.ReconfigureWithConfig(ctx, deps, &nodeCfg)
 	if err != nil {

--- a/gateway/join.go
+++ b/gateway/join.go
@@ -59,7 +59,7 @@ func (g *gateway) handleJoin(ctx context.Context, payload []byte) error {
 		return err
 	}
 
-	g.logger.Infof("sending join accept to device %s", device.NodeName)
+	g.logger.Infof("sending join accept to %s", device.NodeName)
 
 	txPkt := C.struct_lgw_pkt_tx_s{
 		freq_hz:    C.uint32_t(rx2Frequenecy),

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -122,7 +122,7 @@ func decodePayload(ctx context.Context, fPort uint8, path string, data []byte) (
 	//nolint: gosec
 	decoder, err := os.ReadFile(path)
 	if err != nil {
-		return map[string]interface{}{}, err
+		return map[string]interface{}{}, fmt.Errorf("error reading decoder: %w", err)
 	}
 
 	// Convert the byte slice to a string
@@ -130,7 +130,7 @@ func decodePayload(ctx context.Context, fPort uint8, path string, data []byte) (
 
 	readingsMap, err := convertBinaryToMap(ctx, fPort, fileContent, data)
 	if err != nil {
-		return map[string]interface{}{}, err
+		return map[string]interface{}{}, fmt.Errorf("error executing decoder: %w", err)
 	}
 
 	return readingsMap, nil

--- a/milesightct101/sensor.go
+++ b/milesightct101/sensor.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	decoderURL = "https://raw.githubusercontent.com/Milesight-IoT/SensorDecoders/refs/heads/main/CT_Series/CT101/CT101_Decoder.js"
+	decoderURL = "https://raw.githubusercontent.com/Milesight-IoT/SensorDecoders/40e844fedbcf9a8c3b279142672fab1c89bee2e0/" +
+		"CT_Series/CT101/CT101_Decoder.js"
 	// OTAA defaults.
 	defaultAppKey = "5572404C696E6B4C6F52613230313823"
 	// ABP defaults.

--- a/milesightct101/sensor.go
+++ b/milesightct101/sensor.go
@@ -64,15 +64,15 @@ func (conf *Config) getNodeConfig() node.Config {
 		intervalMin = conf.Interval
 	}
 	return node.Config{
-		JoinType:    conf.JoinType,
-		DecoderPath: decoderURL,
-		Interval:    intervalMin,
-		DevEUI:      conf.DevEUI,
-		AppKey:      appKey,
-		AppSKey:     appSKey,
-		NwkSKey:     nwkSKey,
-		DevAddr:     conf.DevAddr,
-		Gateways:    conf.Gateways,
+		JoinType: conf.JoinType,
+		Decoder:  decoderURL,
+		Interval: intervalMin,
+		DevEUI:   conf.DevEUI,
+		AppKey:   appKey,
+		AppSKey:  appSKey,
+		NwkSKey:  nwkSKey,
+		DevAddr:  conf.DevAddr,
+		Gateways: conf.Gateways,
 	}
 }
 
@@ -90,8 +90,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 type CT101 struct {
 	resource.Named
 	logger logging.Logger
-
-	node node.Node
+	node   node.Node
 }
 
 func newCT101(

--- a/milesightem310/em310.go
+++ b/milesightem310/em310.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	decoderURL = "https://raw.githubusercontent.com/Milesight-IoT/SensorDecoders/refs/heads/main/EM_Series/" +
-		"EM300_Series/EM310-TILT/EM310-TILT_Decoder.js"
+	decoderURL = "https://raw.githubusercontent.com/Milesight-IoT/SensorDecoders/fddc96c379ae0999d0fa2baef616b7856010cf14/" +
+		"EM_Series/EM300_Series/EM310-TILT/EM310-TILT_Decoder.js"
 	defaultAppKey  = "5572404C696E6B4C6F52613230313823"
 	defaultNwkSKey = "5572404C696E6B4C6F52613230313823"
 	defaultAppSKey = "5572404C696E6B4C6F52613230313823"

--- a/milesightem310/em310.go
+++ b/milesightem310/em310.go
@@ -63,15 +63,15 @@ func (conf *Config) getNodeConfig() node.Config {
 	}
 
 	return node.Config{
-		JoinType:    conf.JoinType,
-		DecoderPath: decoderURL,
-		Interval:    intervalMin,
-		DevEUI:      conf.DevEUI,
-		AppKey:      appKey,
-		AppSKey:     appSKey,
-		NwkSKey:     nwkSKey,
-		DevAddr:     conf.DevAddr,
-		Gateways:    conf.Gateways,
+		JoinType: conf.JoinType,
+		Decoder:  decoderURL,
+		Interval: intervalMin,
+		DevEUI:   conf.DevEUI,
+		AppKey:   appKey,
+		AppSKey:  appSKey,
+		NwkSKey:  nwkSKey,
+		DevAddr:  conf.DevAddr,
+		Gateways: conf.Gateways,
 	}
 }
 
@@ -89,9 +89,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 type em310Tilt struct {
 	resource.Named
 	logger logging.Logger
-
-	node        node.Node
-	decoderPath string
+	node   node.Node
 }
 
 func newEM310Tilt(

--- a/node/node.go
+++ b/node/node.go
@@ -4,7 +4,6 @@ package node
 import (
 	"context"
 	"errors"
-	"net/url"
 
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/data"
@@ -50,15 +49,15 @@ var noReadings = map[string]interface{}{"": "no readings available yet"}
 
 // Config defines the node's config.
 type Config struct {
-	JoinType    string   `json:"join_type,omitempty"`
-	DecoderPath string   `json:"decoder_path"`
-	Interval    *float64 `json:"uplink_interval_mins"`
-	DevEUI      string   `json:"dev_eui,omitempty"`
-	AppKey      string   `json:"app_key,omitempty"`
-	AppSKey     string   `json:"app_s_key,omitempty"`
-	NwkSKey     string   `json:"network_s_key,omitempty"`
-	DevAddr     string   `json:"dev_addr,omitempty"`
-	Gateways    []string `json:"gateways"`
+	JoinType string   `json:"join_type,omitempty"`
+	Decoder  string   `json:"decoder_path"`
+	Interval *float64 `json:"uplink_interval_mins"`
+	DevEUI   string   `json:"dev_eui,omitempty"`
+	AppKey   string   `json:"app_key,omitempty"`
+	AppSKey  string   `json:"app_s_key,omitempty"`
+	NwkSKey  string   `json:"network_s_key,omitempty"`
+	DevAddr  string   `json:"dev_addr,omitempty"`
+	Gateways []string `json:"gateways"`
 }
 
 func init() {
@@ -72,7 +71,7 @@ func init() {
 
 // Validate ensures all parts of the config are valid.
 func (conf *Config) Validate(path string) ([]string, error) {
-	if conf.DecoderPath == "" {
+	if conf.Decoder == "" {
 		return nil, resource.NewConfigValidationError(path, ErrDecoderPathRequired)
 	}
 
@@ -270,12 +269,4 @@ func (n *Node) Readings(ctx context.Context, extra map[string]interface{}) (map[
 		return reading.(map[string]interface{}), nil
 	}
 	return map[string]interface{}{}, errors.New("node does not have gateway")
-}
-
-func isValidURL(str string) bool {
-	parsedURL, err := url.ParseRequestURI(str)
-	if err != nil {
-		return false
-	}
-	return parsedURL.Scheme != "" && parsedURL.Host != ""
 }

--- a/node/node.go
+++ b/node/node.go
@@ -4,6 +4,9 @@ package node
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/url"
+	"time"
 
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/data"
@@ -176,6 +179,13 @@ func newNode(
 		NodeName: conf.ResourceName().AsNamed().Name().Name,
 	}
 
+	cfg, err := resource.NativeConfig[*Config](conf)
+	if err != nil {
+		return err
+	}
+
+
+
 	err := n.Reconfigure(ctx, deps, conf)
 	if err != nil {
 		return nil, err
@@ -269,4 +279,12 @@ func (n *Node) Readings(ctx context.Context, extra map[string]interface{}) (map[
 		return reading.(map[string]interface{}), nil
 	}
 	return map[string]interface{}{}, errors.New("node does not have gateway")
+}
+
+func isValidURL(str string) bool {
+	parsedURL, err := url.ParseRequestURI(str)
+	if err != nil {
+		return false
+	}
+	return parsedURL.Scheme != "" && parsedURL.Host != ""
 }

--- a/node/node.go
+++ b/node/node.go
@@ -4,9 +4,7 @@ package node
 import (
 	"context"
 	"errors"
-	"net/http"
 	"net/url"
-	"time"
 
 	"go.viam.com/rdk/components/sensor"
 	"go.viam.com/rdk/data"
@@ -178,13 +176,6 @@ func newNode(
 		// may be different if using remotes
 		NodeName: conf.ResourceName().AsNamed().Name().Name,
 	}
-
-	cfg, err := resource.NativeConfig[*Config](conf)
-	if err != nil {
-		return err
-	}
-
-
 
 	err := n.Reconfigure(ctx, deps, conf)
 	if err != nil {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -40,7 +40,8 @@ const (
 var (
 	testInterval     = 5.0
 	testNodeReadings = map[string]interface{}{"reading": 1}
-	testDecoderURL   = "https://raw.githubusercontent.com/Milesight-IoT/SensorDecoders/refs/heads/main/CT_Series/CT101/CT101_Decoder.js"
+	testDecoderURL   = "https://raw.githubusercontent.com/Milesight-IoT/SensorDecoders/40e844fedbcf9a8c3b279142672fab1c89bee2e0/" +
+		"CT_Series/CT101/CT101_Decoder.js"
 )
 
 func createMockGateway() *inject.Sensor {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-
 	// Common test values.
 	testDecoderPath = "/path/to/decoder"
 
@@ -254,6 +253,14 @@ func TestNewNode(t *testing.T) {
 	deps := make(resource.Dependencies)
 	deps[encoder.Named(testGatewayName)] = mockGateway
 
+	tmpDir := t.TempDir()
+	testDecoderPath := fmt.Sprintf("%s/%s", tmpDir, "decoder.js")
+
+	// Create the file
+	file, err := os.Create(testDecoderPath)
+	test.That(t, err, test.ShouldBeNil)
+	defer file.Close()
+
 	// Test OTAA config
 	validConf := resource.Config{
 		Name: "test-node",
@@ -319,7 +326,6 @@ func TestNewNode(t *testing.T) {
 		},
 	}
 
-	tmpDir := t.TempDir()
 	t.Setenv("VIAM_MODULE_DATA", tmpDir)
 
 	n, err = newNode(ctx, deps, validConf, logger)
@@ -341,6 +347,14 @@ func TestReadings(t *testing.T) {
 	mockGateway := createMockGateway()
 	deps := make(resource.Dependencies)
 	deps[encoder.Named(testGatewayName)] = mockGateway
+
+	tmpDir := t.TempDir()
+	testDecoderPath := fmt.Sprintf("%s/%s", tmpDir, "decoder.js")
+
+	// Create the file
+	file, err := os.Create(testDecoderPath)
+	test.That(t, err, test.ShouldBeNil)
+	defer file.Close()
 
 	validConf := resource.Config{
 		Name: "test-node",

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -327,7 +327,6 @@ func TestNewNode(t *testing.T) {
 	}
 
 	t.Setenv("VIAM_MODULE_DATA", tmpDir)
-
 	n, err = newNode(ctx, deps, validConf, logger)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, n, test.ShouldNotBeNil)
@@ -338,6 +337,23 @@ func TestNewNode(t *testing.T) {
 	expectedPath := filepath.Join(tmpDir, "CT101_Decoder.js")
 	test.That(t, node.DecoderPath, test.ShouldEqual, expectedPath)
 	n.Close(ctx)
+
+	// Invalid decoder file should error
+	invalidDecoderConf := resource.Config{
+		Name: "test-node",
+		ConvertedAttributes: &Config{
+			Decoder:  "/worong/path",
+			Interval: &testInterval,
+			JoinType: JoinTypeOTAA,
+			DevEUI:   testDevEUI,
+			AppKey:   testAppKey,
+		},
+	}
+
+	n, err = newNode(ctx, deps, invalidDecoderConf, logger)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "provided decoder file path is not valid")
+
 }
 
 func TestReadings(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -517,7 +517,7 @@ func TestIsValidURL(t *testing.T) {
 	}
 
 	for _, url := range validURLs {
-		test.That(t, isValidURL(url), test.ShouldBeTrue, url)
+		test.That(t, isValidURL(url), test.ShouldBeTrue)
 	}
 
 	// Test invalid URLs
@@ -535,7 +535,7 @@ func TestIsValidURL(t *testing.T) {
 	}
 
 	for _, url := range invalidURLs {
-		test.That(t, isValidURL(url), test.ShouldBeFalse, url)
+		test.That(t, isValidURL(url), test.ShouldBeFalse)
 	}
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -318,10 +318,8 @@ func TestNewNode(t *testing.T) {
 		},
 	}
 
-	oldEnvVarValue := os.Getenv("VIAM_MODULE_DATA")
-	defer os.Setenv("VIAM_MODULE_DATA", oldEnvVarValue)
 	tmpDir := t.TempDir()
-	os.Setenv("VIAM_MODULE_DATA", tmpDir)
+	t.Setenv("VIAM_MODULE_DATA", tmpDir)
 
 	n, err = newNode(ctx, deps, validConf, logger)
 	test.That(t, err, test.ShouldBeNil)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -332,7 +332,7 @@ func TestNewNode(t *testing.T) {
 	test.That(t, node.JoinType, test.ShouldEqual, JoinTypeOTAA)
 	expectedPath := filepath.Join(tmpDir, "CT101_Decoder.js")
 	test.That(t, node.DecoderPath, test.ShouldEqual, expectedPath)
-
+	n.Close(ctx)
 }
 
 func TestReadings(t *testing.T) {

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -59,6 +59,19 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 	}
 
 	n.DecoderPath = cfg.DecoderPath
+	// if the decoder path is a url, save the file
+	if isValidURL(n.DecoderPath) {
+		decoderFilename := n.NodeName + "decoder.js"
+		httpClient := &http.Client{
+			Timeout: time.Second * 25,
+		}
+		decoderFilePath, err := WriteDecoderFileFromURL(ctx, decoderFilename, cfg.DecoderPath, httpClient, n.logger)
+		if err != nil {
+			return err
+		}
+		n.DecoderPath = decoderFilePath
+	}
+
 	n.JoinType = cfg.JoinType
 
 	if n.JoinType == "" {

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -10,7 +10,9 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"go.viam.com/rdk/logging"
@@ -61,7 +63,13 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 	n.DecoderPath = cfg.DecoderPath
 	// if the decoder path is a url, save the file
 	if isValidURL(n.DecoderPath) {
-		decoderFilename := n.NodeName + "decoder.js"
+		decoderFilename := path.Base(n.DecoderPath)
+		// Check if the extension is .js
+		if !strings.HasSuffix(decoderFilename, ".js") {
+			// Change extension to .js
+			decoderFilename = strings.TrimSuffix(decoderFilename, path.Ext(decoderFilename)) + ".js"
+		}
+
 		httpClient := &http.Client{
 			Timeout: time.Second * 25,
 		}

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -62,6 +62,9 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 	}
 
 	n.DecoderPath = cfg.Decoder
+
+	n.logger.Infof("HERE")
+	n.logger.Infof(n.DecoderPath)
 	// if the decoder path is a url, save the file
 	if isValidURL(n.DecoderPath) {
 		decoderFilename := path.Base(n.DecoderPath)
@@ -79,8 +82,9 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 			return err
 		}
 		n.DecoderPath = decoderFilePath
+	} else if err := isValidFilePath(n.DecoderPath); err != nil {
+		return fmt.Errorf("provided decoder file path is not valid: %v", err)
 	}
-
 	n.JoinType = cfg.JoinType
 
 	if n.JoinType == "" {
@@ -235,4 +239,21 @@ func isValidURL(str string) bool {
 		return false
 	}
 	return parsedURL.Scheme != "" && parsedURL.Host != ""
+}
+
+func isValidFilePath(path string) error {
+	// Get file info
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("error checking file: %v", err)
+	}
+
+	if info.IsDir() {
+		return errors.New("path is a directory, not a file")
+	}
+
+	if filepath.Ext(path) != ".js" {
+		return errors.New("decoder must be a .js file")
+	}
+	return nil
 }

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -63,8 +63,6 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 
 	n.DecoderPath = cfg.Decoder
 
-	n.logger.Infof("HERE")
-	n.logger.Infof(n.DecoderPath)
 	// if the decoder path is a url, save the file
 	if isValidURL(n.DecoderPath) {
 		decoderFilename := path.Base(n.DecoderPath)

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -81,7 +81,7 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 		}
 		n.DecoderPath = decoderFilePath
 	} else if err := isValidFilePath(n.DecoderPath); err != nil {
-		return fmt.Errorf("provided decoder file path is not valid: %v", err)
+		return fmt.Errorf("provided decoder file path is not valid: %w", err)
 	}
 	n.JoinType = cfg.JoinType
 
@@ -243,7 +243,7 @@ func isValidFilePath(path string) error {
 	// Get file info
 	info, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("error checking file: %v", err)
+		return fmt.Errorf("error checking file: %w", err)
 	}
 
 	if info.IsDir() {

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,7 +61,7 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 		n.AppSKey = appSKey
 	}
 
-	n.DecoderPath = cfg.DecoderPath
+	n.DecoderPath = cfg.Decoder
 	// if the decoder path is a url, save the file
 	if isValidURL(n.DecoderPath) {
 		decoderFilename := path.Base(n.DecoderPath)
@@ -73,7 +74,7 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 		httpClient := &http.Client{
 			Timeout: time.Second * 25,
 		}
-		decoderFilePath, err := WriteDecoderFileFromURL(ctx, decoderFilename, cfg.DecoderPath, httpClient, n.logger)
+		decoderFilePath, err := WriteDecoderFileFromURL(ctx, decoderFilename, cfg.Decoder, httpClient, n.logger)
 		if err != nil {
 			return err
 		}
@@ -226,4 +227,12 @@ func WriteDecoderFileFromURL(ctx context.Context, decoderFilename, url string,
 	}
 
 	return filePath, nil
+}
+
+func isValidURL(str string) bool {
+	parsedURL, err := url.ParseRequestURI(str)
+	if err != nil {
+		return false
+	}
+	return parsedURL.Scheme != "" && parsedURL.Host != ""
 }


### PR DESCRIPTION
Allows the decoder_path in generic node model to be a HTTP link. Tested that all 4 node models still behave as expected.