### PR TITLE
Check for invalid payload lengths

### DIFF
--- a/gateway/join.go
+++ b/gateway/join.go
@@ -61,6 +61,9 @@ func (g *gateway) handleJoin(ctx context.Context, payload []byte, packetTime tim
 // | 1 B  |   8 B    |    8 B   |     2 B      |  4 B  |
 // https://lora-alliance.org/wp-content/uploads/2020/11/lorawan1.0.3.pdf page 34 for more info on join request.
 func (g *gateway) parseJoinRequestPacket(payload []byte) (joinRequest, *node.Node, error) {
+	if len(payload) != 23 {
+		return joinRequest{}, nil, errInvalidLength
+	}
 	var joinRequest joinRequest
 
 	// everything in the join request payload is little endian

--- a/gateway/join.go
+++ b/gateway/join.go
@@ -61,6 +61,7 @@ func (g *gateway) handleJoin(ctx context.Context, payload []byte, packetTime tim
 // | 1 B  |   8 B    |    8 B   |     2 B      |  4 B  |
 // https://lora-alliance.org/wp-content/uploads/2020/11/lorawan1.0.3.pdf page 34 for more info on join request.
 func (g *gateway) parseJoinRequestPacket(payload []byte) (joinRequest, *node.Node, error) {
+	// join request should always contain 23 bytes, if not something went wrong.
 	if len(payload) != 23 {
 		return joinRequest{}, nil, errInvalidLength
 	}

--- a/gateway/join_test.go
+++ b/gateway/join_test.go
@@ -126,6 +126,11 @@ func TestParseJoinRequestPacket(t *testing.T) {
 	_, _, err = g.parseJoinRequestPacket(unknownPayload)
 	test.That(t, err, test.ShouldEqual, errNoDevice)
 
+	// Test invalid length
+	_, _, err = g.parseJoinRequestPacket([]byte{0x00, 0x00})
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, errInvalidLength)
+
 	err = g.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -34,8 +34,9 @@ var errInvalidLength = errors.New("unexpected payload length")
 func (g *gateway) parseDataUplink(ctx context.Context, phyPayload []byte, packetTime time.Time, snr float64, sf int) (
 	string, map[string]interface{}, error,
 ) {
+	// payload should be at least 13 bytes
 	if len(phyPayload) < 13 {
-		return "", map[string]interface{}{}, errInvalidLength
+		return "", map[string]interface{}{}, fmt.Errorf("%w, payload should be at least 13 bytes but got %d", errInvalidLength, len(phyPayload))
 	}
 
 	devAddr := phyPayload[1:5]
@@ -64,7 +65,7 @@ func (g *gateway) parseDataUplink(ctx context.Context, phyPayload []byte, packet
 	foptsLength := fctrl & 0x0F
 
 	if len(phyPayload) < 8+int(foptsLength) {
-		return "", map[string]interface{}{}, errInvalidLength
+		return "", map[string]interface{}{}, fmt.Errorf("%w, got fopts length of %d but don't have enough bytes", errInvalidLength, foptsLength)
 	}
 
 	fopts := phyPayload[8 : 8+foptsLength]

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -137,14 +138,14 @@ func TestParseDataUplink(t *testing.T) {
 	// Test invalid length
 	_, _, err = g.parseDataUplink(context.Background(), []byte{0x00, 0x00}, time.Now(), 0, 0)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err, test.ShouldBeError, errInvalidLength)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "unexpected payload length, payload should be at least 13 bytes")
 
 	// Test invalid fopts length
 	validPayload = validPayload[:len(validPayload)-13]
 	validPayload[5] = 0x88 // expected fopts length is 8 bytes, but whole payload only 14 bytes
 	_, _, err = g.parseDataUplink(context.Background(), validPayload, time.Now(), 0, 0)
 	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err, test.ShouldBeError, errInvalidLength)
+	test.That(t, errors.Is(err, errInvalidLength), test.ShouldBeTrue)
 
 	// Test no frame payload
 	noFramePayload, err := createUplinkData(testDeviceAddr, []byte{})

--- a/gateway/uplink_test.go
+++ b/gateway/uplink_test.go
@@ -134,6 +134,25 @@ func TestParseDataUplink(t *testing.T) {
 	_, _, err = g.parseDataUplink(context.Background(), validPayload, time.Now(), 0, 0)
 	test.That(t, err, test.ShouldBeNil)
 
+	// Test invalid length
+	_, _, err = g.parseDataUplink(context.Background(), []byte{0x00, 0x00}, time.Now(), 0, 0)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, errInvalidLength)
+
+	// Test invalid fopts length
+	validPayload = validPayload[:len(validPayload)-13]
+	validPayload[5] = 0x88 // expected fopts length is 8 bytes, but whole payload only 14 bytes
+	_, _, err = g.parseDataUplink(context.Background(), validPayload, time.Now(), 0, 0)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, errInvalidLength)
+
+	// Test no frame payload
+	noFramePayload, err := createUplinkData(testDeviceAddr, []byte{})
+	test.That(t, err, test.ShouldBeNil)
+	_, _, err = g.parseDataUplink(context.Background(), noFramePayload, time.Now(), 0, 0)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "sent packet with no data")
+
 	err = g.Close(context.Background())
 	test.That(t, err, test.ShouldBeNil)
 }


### PR DESCRIPTION
Got a panic when a join request didn't contain the expected data, adding checks to error if a payload doesn't have the expected bytes. 