### PR TITLE
RSDK-10585 Add USB support to generic gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,19 @@ Navigate to the **CONFIGURE** tab of your machine in the [Viam app](https://app.
 
 ## Configure the `viam:sensor:sx1302-gateway`
 
-Example gateway configuration:
+Example gateway configuration for SPI gateway:
+```json
+{
+    "board": "rpi",
+    "spi_bus": 0,
+    "reset_pin": int,
+    "power_en_pin": int,
+    "region_code": "US915"
+}
+```
+
+
+Example gateway configuration for USB gateway:
 ```json
 {
     "board": "rpi",

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Example gateway configuration:
 ```json
 {
     "board": "rpi",
-    "spi_bus": 0,
+    "path": "/dev/path",
     "reset_pin": int,
     "power_en_pin": int,
-    "region_code": "US915"
+    "region_code": "US915",
 }
 ```
 
@@ -61,6 +61,7 @@ The following attributes are available for `viam:sensor:sx1302-gateway` sensors:
 | spi_bus | int | no | 0 | SPI bus number (0 or 1) |
 | power_en_pin | int | no | - | GPIO pin number for the power enable pin |
 | region_code | string | no | US915 | frequency region of your gateway (US915 or EU868) |
+| path | string | required for USB gateways | - | serial or SPI device path the concentrator is connected to |
 
 ## Setup the `viam:sensor:sx1302-hat-generic`
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following attributes are available for `viam:sensor:sx1302-gateway` sensors:
 | spi_bus | int | no | 0 | SPI bus number (0 or 1) |
 | power_en_pin | int | no | - | GPIO pin number for the power enable pin |
 | region_code | string | no | US915 | frequency region of your gateway (US915 or EU868) |
-| path | string | required for USB gateways | - | serial or SPI device path the concentrator is connected to |
+| path | string | required for USB gateways | - | serial device path the concentrator is connected to |
 
 ## Setup the `viam:sensor:sx1302-hat-generic`
 

--- a/dragino/downlink.go
+++ b/dragino/downlink.go
@@ -15,7 +15,7 @@ const (
 	IntervalBytes  = 3
 )
 
-// DraginoResetRequest defines the reset downlink for draginos
+// DraginoResetRequest defines the reset downlink for draginos.
 var DraginoResetRequest = node.ResetRequest{
 	Header:     ResetHeader,
 	PayloadHex: ResetPayload,

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -93,6 +93,7 @@ type Config struct {
 	ResetPin  *int   `json:"reset_pin"`
 	BoardName string `json:"board"`
 	Region    string `json:"region_code,omitempty"`
+	Path      string `json:"path,omitempty"`
 }
 
 // deviceInfo is a struct containing OTAA device information.

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -37,21 +37,42 @@ func setupFileAndGateway(t *testing.T) *gateway {
 }
 
 func TestValidate(t *testing.T) {
-	// Test valid config with default bus
+	// Test valid config with USB path
 	resetPin := 25
 	conf := &Config{
 		BoardName: "pi",
 		ResetPin:  &resetPin,
+		Path:      "/dev/ttyUSB0",
 	}
 	deps, err := conf.Validate("")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(deps), test.ShouldEqual, 1)
 
-	// Test valid config with bus=1
+	// Test valid config with SPI path
 	conf = &Config{
 		BoardName: "pi",
 		ResetPin:  &resetPin,
-		Bus:       1,
+		Path:      "/dev/spidev0.0",
+	}
+	deps, err = conf.Validate("")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(deps), test.ShouldEqual, 1)
+
+	// Test valid config with default bus
+	conf = &Config{
+		BoardName: "pi",
+		ResetPin:  &resetPin,
+	}
+	deps, err = conf.Validate("")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(deps), test.ShouldEqual, 1)
+
+	// Test valid config with bus=1
+	bus := 1
+	conf = &Config{
+		BoardName: "pi",
+		ResetPin:  &resetPin,
+		Bus:       &bus,
 	}
 	deps, err = conf.Validate("")
 	test.That(t, err, test.ShouldBeNil)
@@ -65,11 +86,12 @@ func TestValidate(t *testing.T) {
 	test.That(t, err, test.ShouldBeError, resource.NewConfigValidationFieldRequiredError("", "reset_pin"))
 	test.That(t, deps, test.ShouldBeNil)
 
+	bus = 3
 	// Test invalid bus value
 	conf = &Config{
 		BoardName: "pi",
 		ResetPin:  &resetPin,
-		Bus:       2,
+		Bus:       &bus,
 	}
 	deps, err = conf.Validate("")
 	test.That(t, err, test.ShouldBeError, resource.NewConfigValidationError("", errInvalidSpiBus))
@@ -563,12 +585,13 @@ func TestNativeConfig(t *testing.T) {
 	t.Run("Test Default Config", func(t *testing.T) {
 		resetPin := 85
 		powerPin := 74
+		bus := 1
 		validConf := resource.Config{
 			Name: "test-default",
 			ConvertedAttributes: &Config{
 				BoardName: "pi",
 				ResetPin:  &resetPin,
-				Bus:       1,
+				Bus:       &bus,
 				PowerPin:  &powerPin,
 			},
 			Model: ModelGenericHat,

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -48,16 +48,6 @@ func TestValidate(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(deps), test.ShouldEqual, 1)
 
-	// Test valid config with SPI path
-	conf = &Config{
-		BoardName: "pi",
-		ResetPin:  &resetPin,
-		Path:      "/dev/spidev0.0",
-	}
-	deps, err = conf.Validate("")
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, len(deps), test.ShouldEqual, 1)
-
 	// Test valid config with default bus
 	conf = &Config{
 		BoardName: "pi",
@@ -77,6 +67,17 @@ func TestValidate(t *testing.T) {
 	deps, err = conf.Validate("")
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, len(deps), test.ShouldEqual, 1)
+
+	// Test error if bus and path are configured
+	conf = &Config{
+		BoardName: "pi",
+		ResetPin:  &resetPin,
+		Bus:       &bus,
+		Path:      "/dev/ttyUSB0",
+	}
+	deps, err = conf.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err, test.ShouldBeError, resource.NewConfigValidationError("", errSPIAndUSB))
 
 	// Test missing reset pin
 	conf = &Config{

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -76,8 +76,8 @@ func TestValidate(t *testing.T) {
 		Path:      "/dev/ttyUSB0",
 	}
 	deps, err = conf.Validate("")
-	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err, test.ShouldBeError, resource.NewConfigValidationError("", errSPIAndUSB))
+	test.That(t, deps, test.ShouldBeNil)
 
 	// Test missing reset pin
 	conf = &Config{

--- a/gateway/waveshare_hat.go
+++ b/gateway/waveshare_hat.go
@@ -24,7 +24,7 @@ type ConfigSX1302WaveshareHAT struct {
 func (conf *ConfigSX1302WaveshareHAT) getGatewayConfig() *Config {
 	powerPin := waveshareHatPowerPin
 	resetPin := waveshareHatResetPin
-	return &Config{Bus: conf.Bus, BoardName: conf.BoardName, PowerPin: &powerPin, ResetPin: &resetPin, Region: conf.Region}
+	return &Config{Bus: &conf.Bus, BoardName: conf.BoardName, PowerPin: &powerPin, ResetPin: &resetPin, Region: conf.Region}
 }
 
 // Validate ensures all parts of the config are valid.

--- a/lorahw/gateway.c
+++ b/lorahw/gateway.c
@@ -30,7 +30,7 @@ const int32_t ifFrequencies[9] = {
 // This defines what RF chain to use for each of the 8 if chains
 const int32_t rfChains [9] = {0, 0, 0, 0, 0, 1, 1, 1};
 
-int set_up_gateway(int bus, int region) {
+int set_up_gateway(int com_type, char* path, int region) {
     // the board config defines parameters for the entire gateway HAT.
     struct lgw_conf_board_s boardconf;
 
@@ -38,23 +38,10 @@ int set_up_gateway(int bus, int region) {
     boardconf.lorawan_public = true;
     boardconf.clksrc = 0;
     boardconf.full_duplex = false;
-    boardconf.com_type = LGW_COM_SPI;
+    boardconf.com_type = com_type; // 0 is spi 1 is USB
 
-    const char * com_path;
-
-    switch(bus) {
-        case 0:
-            com_path = "/dev/spidev0.0";
-            break;
-        case 1:
-            com_path = "/dev/spidev0.1";
-            break;
-        default:
-            //error invalid spi bus
-            return 1;
-    }
-
-    strncpy(boardconf.com_path, com_path, sizeof boardconf.com_path);
+    strncpy(boardconf.com_path, path, sizeof boardconf.com_path);
+    // add null terminator
     boardconf.com_path[sizeof boardconf.com_path - 1] = '\0';
     if (lgw_board_setconf(&boardconf) != LGW_HAL_SUCCESS) {
         return 2;

--- a/lorahw/gateway.h
+++ b/lorahw/gateway.h
@@ -10,7 +10,7 @@ int receive(struct lgw_pkt_rx_s* packet);
 int send(struct lgw_pkt_tx_s* packet);
 int stop_gateway(void);
 int start_gateway(void);
-int set_up_gateway(int bus, int region);
+int set_up_gateway(int com_type, char* path, int region) ;
 void disable_buffering(void);
 void redirect_to_pipe(int fd);
 int get_status(uint8_t rf, uint8_t* status);

--- a/lorahw/lorahw.go
+++ b/lorahw/lorahw.go
@@ -36,7 +36,7 @@ var (
 	errGatewayStart           = errors.New("error starting the gateway")
 )
 
-// ComType defines connection the concentrator.
+// ComType defines connection type to the concentrator.
 type ComType int
 
 // enum for com types

--- a/lorahw/lorahw.go
+++ b/lorahw/lorahw.go
@@ -36,6 +36,15 @@ var (
 	errGatewayStart           = errors.New("error starting the gateway")
 )
 
+// ComType defines connection the concentrator.
+type ComType int
+
+// enum for com types
+const (
+	SPI ComType = iota
+	USB
+)
+
 // SendPacket sends a lora packet using the sx1302 concentrator
 func SendPacket(ctx context.Context, pkt *TxPacket) error {
 	if pkt == nil {
@@ -108,8 +117,8 @@ type RxPacket struct {
 }
 
 // SetupGateway initializes the gateway hardware
-func SetupGateway(spiBus int, region regions.Region) error {
-	errCode := C.set_up_gateway(C.int(spiBus), C.int(region))
+func SetupGateway(comType ComType, path string, region regions.Region) error {
+	errCode := C.set_up_gateway(C.int(comType), C.CString(path), C.int(region))
 	if errCode != 0 {
 		return fmt.Errorf("failed to set up gateway: %w", parseErrorCode(int(errCode)))
 	}

--- a/lorahw/lorahw_test.go
+++ b/lorahw/lorahw_test.go
@@ -98,15 +98,14 @@ func TestReceivePackets(t *testing.T) {
 
 func TestSetupGateway(t *testing.T) {
 	// Test successful case
-	err := SetupGateway(1, regions.US)
+	err := SetupGateway(0, "/dev/spidev0.0", regions.US)
 	test.That(t, err, test.ShouldBeNil)
 
 	// unspecifed region will not error
-	err = SetupGateway(1, regions.Unspecified)
+	err = SetupGateway(0, "/dev/spidev0.0", regions.Unspecified)
 	test.That(t, err, test.ShouldBeNil)
 
-	// Test invalid SPI bus
-	err = SetupGateway(999, regions.US)
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, errors.Is(err, errInvalidSpiBus), test.ShouldBeTrue)
+	// Test
+	err = SetupGateway(1, "/dev/ttyACM0", regions.US)
+	test.That(t, err, test.ShouldBeNil)
 }


### PR DESCRIPTION
Adds optional attribute `path` to generic gateway that can be used to specify the serial or SPI path. the com type is determined based on the value of `path` attribute. `spi_bus` can also still be used for SPI to avoid breaking anything.

Tested on the rak USB concentrators and confirmed SPI still works with waveshare hat.