### PR TITLE
RSDK-10686 using serial by-path causes buffer overflow error 

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -147,7 +147,7 @@ func (conf *Config) Validate(path string) ([]string, error) {
 	}
 
 	if conf.Path != "" {
-		err := validateSerialPath(path)
+		err := validateSerialPath(conf.Path)
 		if err != nil {
 			return nil, err
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -346,13 +346,10 @@ func (g *gateway) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 			if err != nil {
 				return fmt.Errorf("failed to resolve symlink of path %s: %v", cfg.Path, err)
 			}
-
-			g.logger.Infof("Resolved path: %s\n", resolvedPath)
 			cfg.Path = resolvedPath
 		}
 		path = cfg.Path
 		comType = lorahw.USB
-
 	}
 	var comTypeString string
 	switch comType {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -38,9 +38,8 @@ const (
 // Error variables for validation and operations.
 var (
 	// Config validation errors.
-	errInvalidSpiBus    = errors.New("spi bus can be 0 or 1 - default 0")
-	errSPIAndUSB        = errors.New("cannot have both spi_bus and path attributes, add path for USB or spi_bus for SPI gateways")
-	errPathDoesNotExist = errors.New("provided serial path does not exist")
+	errInvalidSpiBus = errors.New("spi bus can be 0 or 1 - default 0")
+	errSPIAndUSB     = errors.New("cannot have both spi_bus and path attributes, add path for USB or spi_bus for SPI gateways")
 
 	// Gateway operation errors.
 	errUnexpectedJoinType = errors.New("unexpected join type when adding node to gateway")

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -239,6 +239,7 @@ func NewGateway(
 
 // look at the resource.Config to determine which model is being used.
 func getNativeConfig(conf resource.Config) (*Config, error) {
+	fmt.Println(conf.Model)
 	switch conf.Model.Name {
 	case genericHat, oldModelName:
 		return resource.NativeConfig[*Config](conf)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -238,7 +238,6 @@ func NewGateway(
 
 // look at the resource.Config to determine which model is being used.
 func getNativeConfig(conf resource.Config) (*Config, error) {
-	fmt.Println(conf.Model)
 	switch conf.Model.Name {
 	case genericHat, oldModelName:
 		return resource.NativeConfig[*Config](conf)
@@ -344,7 +343,7 @@ func (g *gateway) Reconfigure(ctx context.Context, deps resource.Dependencies, c
 		if strings.Contains(cfg.Path, "by-path") || strings.Contains(cfg.Path, "by-id") {
 			resolvedPath, err := filepath.EvalSymlinks(cfg.Path)
 			if err != nil {
-				return fmt.Errorf("failed to resolve symlink of path %s: %v", cfg.Path, err)
+				return fmt.Errorf("failed to resolve symlink of path %s: %w", cfg.Path, err)
 			}
 			cfg.Path = resolvedPath
 		}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -20,11 +20,6 @@ import (
 	"go.viam.com/utils/protoutils"
 )
 
-// intPtr returns a pointer to the given integer value
-func intPtr(i int) *int {
-	return &i
-}
-
 // creates a test gateway with device info populated in the file.
 func setupFileAndGateway(t *testing.T) *gateway {
 	g := createTestGateway(t)
@@ -622,19 +617,19 @@ func TestSymlinkResolution(t *testing.T) {
 
 	// Create test directories to mimic Linux's /dev/serial structure
 	byPathDir := filepath.Join(tmpDir, "by-path")
-	byIdDir := filepath.Join(tmpDir, "by-id")
-	err = os.MkdirAll(byPathDir, 0755)
+	byIDDir := filepath.Join(tmpDir, "by-id")
+	err = os.MkdirAll(byPathDir, 0o755)
 	test.That(t, err, test.ShouldBeNil)
-	err = os.MkdirAll(byIdDir, 0755)
+	err = os.MkdirAll(byIDDir, 0o755)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Create test symlinks
 	byPathLink := filepath.Join(byPathDir, "pci-0000:00:14.0-usb-0:2:1.0")
-	byIdLink := filepath.Join(byIdDir, "usb-FTDI_FT232R_USB_UART_AB0CDEFG-if00-port0")
+	byIDLink := filepath.Join(byIDDir, "usb-FTDI_FT232R_USB_UART_AB0CDEFG-if00-port0")
 
 	err = os.Symlink(deviceFile.Name(), byPathLink)
 	test.That(t, err, test.ShouldBeNil)
-	err = os.Symlink(deviceFile.Name(), byIdLink)
+	err = os.Symlink(deviceFile.Name(), byIDLink)
 	test.That(t, err, test.ShouldBeNil)
 
 	rp := 23
@@ -666,7 +661,7 @@ func TestSymlinkResolution(t *testing.T) {
 				ConvertedAttributes: &Config{
 					BoardName: "mock-board",
 					ResetPin:  &rp,
-					Path:      byIdLink,
+					Path:      byIDLink,
 				},
 			},
 			expectError: false,
@@ -699,11 +694,6 @@ func TestSymlinkResolution(t *testing.T) {
 				test.That(t, err.Error(), test.ShouldContainSubstring, "failed to resolve symlink")
 			}
 			g.Close(context.Background())
-			// } else {
-			// 	// We expect error about hardware initialization, but not about symlink resolution
-			// 	test.That(t, err, test.ShouldNotBeNil)
-			// 	test.That(t, err.Error(), test.ShouldContainSubstring, "error initializing the gateway")
-			// }
 		})
 	}
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -39,12 +39,18 @@ func setupFileAndGateway(t *testing.T) *gateway {
 }
 
 func TestValidate(t *testing.T) {
+	// Create temp file for serial path testing
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "test-serial-*")
+	test.That(t, err, test.ShouldBeNil)
+	defer os.Remove(tmpFile.Name())
+
 	// Test valid config with USB path
 	resetPin := 25
 	conf := &Config{
 		BoardName: "pi",
 		ResetPin:  &resetPin,
-		Path:      "/dev/ttyUSB0",
+		Path:      tmpFile.Name(),
 	}
 	deps, err := conf.Validate("")
 	test.That(t, err, test.ShouldBeNil)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -585,10 +585,9 @@ func TestClose(t *testing.T) {
 }
 
 func TestValidateSerialPath(t *testing.T) {
-	// Create a temporary directory for testing
 	tmpDir := t.TempDir()
 
-	// Test case 1: Path exists
+	//Path exists
 	tmpFile, err := os.CreateTemp(tmpDir, "test-serial-*")
 	test.That(t, err, test.ShouldBeNil)
 	defer os.Remove(tmpFile.Name())
@@ -596,13 +595,13 @@ func TestValidateSerialPath(t *testing.T) {
 	err = validateSerialPath(tmpFile.Name())
 	test.That(t, err, test.ShouldBeNil)
 
-	// Test case 2: Path does not exist
+	// Path does not exist
 	nonExistentPath := filepath.Join(tmpDir, "non-existent-device")
 	err = validateSerialPath(nonExistentPath)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "does not exist")
 
-	// Test case 3: Invalid path format
+	// Invalid path format
 	invalidPath := string([]byte{0x00})
 	err = validateSerialPath(invalidPath)
 	test.That(t, err, test.ShouldNotBeNil)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -271,6 +271,8 @@ func TestNewNode(t *testing.T) {
 	test.That(t, n, test.ShouldNotBeNil)
 
 	testNode = n.(*Node)
+	// lock to prevent a data race w the pollGateway routine
+	testNode.reconfigureMu.Lock()
 	test.That(t, testNode.NodeName, test.ShouldEqual, "test-node-abp")
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeABP)
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, testDecoderPath)
@@ -283,6 +285,7 @@ func TestNewNode(t *testing.T) {
 	expectedAppSKey, err := hex.DecodeString(testutils.TestAppSKey)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, testNode.AppSKey, test.ShouldResemble, expectedAppSKey)
+	testNode.reconfigureMu.Unlock()
 	err = n.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
 
@@ -303,10 +306,12 @@ func TestNewNode(t *testing.T) {
 	test.That(t, n, test.ShouldNotBeNil)
 
 	testNode = n.(*Node)
+	testNode.reconfigureMu.Lock()
 	test.That(t, testNode.NodeName, test.ShouldEqual, testNodeName)
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeOTAA)
 	expectedPath := filepath.Join(tmpDir, "CT101_Decoder.js")
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, expectedPath)
+	testNode.reconfigureMu.Unlock()
 	err = n.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -250,6 +250,7 @@ func TestNewNode(t *testing.T) {
 	test.That(t, testNode.NodeName, test.ShouldEqual, testNodeName)
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeOTAA)
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, testDecoderPath)
+	n.Close(ctx)
 
 	// Test with valid ABP config
 	validABPConf := resource.Config{
@@ -323,6 +324,7 @@ func TestNewNode(t *testing.T) {
 	_, err = newNode(ctx, deps, invalidDecoderConf, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "provided decoder file path is not valid")
+	n.Close(ctx)
 }
 
 func TestReadings(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -325,7 +325,8 @@ func TestNewNode(t *testing.T) {
 	_, err = newNode(ctx, deps, invalidDecoderConf, logger)
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "provided decoder file path is not valid")
-	n.Close(ctx)
+	err = n.Close(ctx)
+	test.That(t, err, test.ShouldBeNil))
 }
 
 func TestReadings(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -250,7 +250,8 @@ func TestNewNode(t *testing.T) {
 	test.That(t, testNode.NodeName, test.ShouldEqual, testNodeName)
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeOTAA)
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, testDecoderPath)
-	n.Close(ctx)
+	err = n.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
 
 	// Test with valid ABP config
 	validABPConf := resource.Config{
@@ -284,7 +285,8 @@ func TestNewNode(t *testing.T) {
 	expectedAppSKey, err := hex.DecodeString(testutils.TestAppSKey)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, testNode.AppSKey, test.ShouldResemble, expectedAppSKey)
-	n.Close(ctx)
+	err = n.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
 
 	// Decoder can be URL
 	validConf = resource.Config{
@@ -307,7 +309,8 @@ func TestNewNode(t *testing.T) {
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeOTAA)
 	expectedPath := filepath.Join(tmpDir, "CT101_Decoder.js")
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, expectedPath)
-	n.Close(ctx)
+	err = n.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
 
 	// Invalid decoder file should error
 	invalidDecoderConf := resource.Config{

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -306,12 +306,10 @@ func TestNewNode(t *testing.T) {
 	test.That(t, n, test.ShouldNotBeNil)
 
 	testNode = n.(*Node)
-	testNode.reconfigureMu.Lock()
 	test.That(t, testNode.NodeName, test.ShouldEqual, testNodeName)
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeOTAA)
 	expectedPath := filepath.Join(tmpDir, "CT101_Decoder.js")
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, expectedPath)
-	testNode.reconfigureMu.Unlock()
 	err = n.Close(ctx)
 	test.That(t, err, test.ShouldBeNil)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -326,7 +326,7 @@ func TestNewNode(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "provided decoder file path is not valid")
 	err = n.Close(ctx)
-	test.That(t, err, test.ShouldBeNil))
+	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestReadings(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -271,8 +271,6 @@ func TestNewNode(t *testing.T) {
 	test.That(t, n, test.ShouldNotBeNil)
 
 	testNode = n.(*Node)
-	testNode.reconfigureMu.Lock()
-	defer testNode.reconfigureMu.Unlock()
 	test.That(t, testNode.NodeName, test.ShouldEqual, "test-node-abp")
 	test.That(t, testNode.JoinType, test.ShouldEqual, JoinTypeABP)
 	test.That(t, testNode.DecoderPath, test.ShouldEqual, testDecoderPath)

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -131,7 +131,6 @@ func (n *Node) ReconfigureWithConfig(ctx context.Context, deps resource.Dependen
 	if n.Workers == nil {
 		n.Workers = utils.NewBackgroundStoppableWorkers(n.PollGateway)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
converting the by-path or by-id path to the symlink so thats its small enough to fit into the c buffer. Tested manually on the rak