### PR TITLE
RSDK-10773 filter out invalid data from WQS-LB probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ This command will send a generic downlink payload to the gateway. the string is 
 ```
 
 ## Configure your dragino sensor
-
 If using a WSQ-LB, be sure to calibrate the sensor using the instructions below.
+Submerge the WQS-LB probes in liquid to obtain valid readings.
 
 Example OTAA node configuration:
 

--- a/draginowqslb/sensor.go
+++ b/draginowqslb/sensor.go
@@ -41,7 +41,7 @@ const (
 	turbidityMax = 10000.
 )
 
-var ProbeRanges = []probeRange{
+var probeRanges = []probeRange{
 	{ecK10Key, ecK10Min, ecK10Max},
 	{ecK1Key, ecK1Min, ecK1Max},
 	{phKey, phMin, phMax},
@@ -185,7 +185,7 @@ func (n *WQSLB) Readings(ctx context.Context, extra map[string]interface{}) (map
 		return map[string]interface{}{}, err
 	}
 
-	for _, probeRange := range ProbeRanges {
+	for _, probeRange := range probeRanges {
 		reading = sanitizeReading(reading, extra, probeRange)
 	}
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -825,7 +825,7 @@ func (g *gateway) Readings(ctx context.Context, extra map[string]interface{}) (m
 	// no readings available yet
 	if len(g.lastReadings) == 0 || g.lastReadings == nil {
 		// Tell the collector not to capture the empty data.
-		if extra[data.FromDMString] == true {
+		if extra != nil && extra[data.FromDMString] == true {
 			return map[string]interface{}{}, data.ErrNoCaptureToStore
 		}
 		return noReadings, nil

--- a/node/node.go
+++ b/node/node.go
@@ -312,7 +312,7 @@ func (n *Node) Readings(ctx context.Context, extra map[string]interface{}) (map[
 		// no readings available yet
 		if !ok {
 			// If the readings call came from data capture, return noCaptureToStore error to indicate not to capture data.
-			if extra[data.FromDMString] == true {
+			if extra != nil && extra[data.FromDMString] == true {
 				return map[string]interface{}{}, data.ErrNoCaptureToStore
 			}
 			return NoReadings, nil


### PR DESCRIPTION
min and max values for each key are based on the ranges from the user manual. The reading will be removed from captured data, and other calls will return an "INVALID" string. Tested manually that the EC K10 invalid data returns string/captured data does not contain the EC K10 value.