### PR TITLE
RSDK-10507 only log a warning if the interval is lower than the legal limit

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -781,6 +781,16 @@ func TestIntervalDownlink(t *testing.T) {
 			testGatewayReturn: false,
 			expectedErr:       "cannot send interval downlink, interval of 256 minutes exceeds maximum number of bytes 1",
 		},
+		{
+			name:              "interval lower than min",
+			interval:          0.5,
+			payloadUnits:      Seconds,
+			numBytes:          4,
+			useLittleEndian:   false,
+			header:            "02",
+			expectedReturn:    "020000001E", // 0.5 min = 30 seconds = 1E in hex
+			testGatewayReturn: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -781,18 +781,6 @@ func TestIntervalDownlink(t *testing.T) {
 			testGatewayReturn: false,
 			expectedErr:       "cannot send interval downlink, interval of 256 minutes exceeds maximum number of bytes 1",
 		},
-		{
-			name:              "interval lower than min",
-			interval:          0.5,
-			payloadUnits:      Seconds,
-			numBytes:          4,
-			useLittleEndian:   false,
-			header:            "ff8e",
-			expectedReturn:    "",
-			testGatewayReturn: false,
-			expectedErr: `requested uplink interval (0.50 minutes) exceeds the legal duty cycle limit of 1.00 minutes,
-			increase the uplink interval`,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -366,9 +366,8 @@ func (n *Node) SendIntervalDownlink(ctx context.Context, req IntervalRequest) (m
 	n.reconfigureMu.Lock()
 	if n.MinIntervalSeconds != 0 {
 		if n.MinIntervalSeconds > (req.IntervalMin * 60.0) {
-			n.reconfigureMu.Unlock()
-			return nil, fmt.Errorf(`requested uplink interval (%.2f minutes) exceeds the legal duty cycle limit of %.2f minutes,
-			increase the uplink interval`, req.IntervalMin, n.MinIntervalSeconds/60.0)
+			n.logger.Warnf(`requested uplink interval (%.2f minutes) exceeds the legal duty cycle limit of %.2f minutes,
+			consider increasing the uplink interval`, req.IntervalMin, n.MinIntervalSeconds/60.0)
 		}
 	}
 	n.reconfigureMu.Unlock()

--- a/node/node_utils.go
+++ b/node/node_utils.go
@@ -366,6 +366,7 @@ func (n *Node) SendIntervalDownlink(ctx context.Context, req IntervalRequest) (m
 	n.reconfigureMu.Lock()
 	if n.MinIntervalSeconds != 0 {
 		if n.MinIntervalSeconds > (req.IntervalMin * 60.0) {
+			// user preference in the EU is to warn the user of this limit, rather than prevent them from setting it at all.
 			n.logger.Warnf(`requested uplink interval (%.2f minutes) exceeds the legal duty cycle limit of %.2f minutes,
 			consider increasing the uplink interval`, req.IntervalMin, n.MinIntervalSeconds/60.0)
 		}


### PR DESCRIPTION
Based on felix's feedback, warn instead of error if the interval is too low 