### PR TITLE
Update README and meta.json with learnings from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ Example OTAA node configuration:
 ```json
 {
   "join_type": "OTAA",
-  "dev_addr": <string>,
-  "app_s_key": <string>,
-  "network_s_key": <string>,
+  "dev_eui": <string>,
+  "app_key": <string>,
   "gateways": [<string>]
 }
 ```
@@ -76,8 +75,9 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_eui": <string>,
-  "app_key": <string>,
+  "dev_addr": <string>,
+  "app_s_key": <string>,
+  "network_s_key": <string>,
   "gateways": [<string>]
 }
 ```
@@ -95,16 +95,16 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 > [!NOTE]
 > If you use the WQS-LB, be sure to [calibrate the sensor](https://docs.viam.com/operate/reference/components/sensor/lorawan/#calibrate-the-dragino-wqs-lb-water-quality-sensor).
@@ -159,7 +159,7 @@ Example OTAA node configuration:
 ```json
 {
   "join_type": "OTAA",
-  "dev_addr": <string>,
+  "dev_eui": <string>,
   "gateways": [<string>]
 }
 ```
@@ -169,7 +169,7 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_eui": <string>,
+  "dev_addr": <string>,
   "gateways": [<string>]
 }
 ```
@@ -186,17 +186,16 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | no | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | no | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | no | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | no | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
-
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | no | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | no | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### DoCommand
 
@@ -246,9 +245,8 @@ Example OTAA node configuration:
 ```json
 {
   "join_type": "OTAA",
-  "dev_addr": <string>,
-  "app_s_key": <string>,
-  "network_s_key": <string>,
+  "dev_eui": <string>,
+  "app_key": <string>,
   "gateways": [<string>],
   "decoder_path": <string>
 }
@@ -259,8 +257,9 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_eui": <string>,
-  "app_key": <string>,
+  "dev_addr": <string>,
+  "app_s_key": <string>,
+  "network_s_key": <string>,
   "gateways": [<string>],
   "decoder_path": <string>
 }
@@ -280,16 +279,16 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### DoCommand
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ See below for the Viam configuration for each of these models.
 
 ### Configuration for `viam:lorawan:dragino-LHT65N` and `viam:lorawan:dragino-WQS-LB`
 
+Before using the Dragino WQS-LB, you must calibrate the sensor. For instructions on how to calibrate your sensor, see [the Viam documentation](https://docs.viam.com/operate/reference/components/sensor/lorawan/#calibrate-the-dragino-wqs-lb-water-quality-sensor)
+
 #### Examples
 
 Example OTAA node configuration:
@@ -147,84 +149,6 @@ Send a generic downlink payload (in hexadecimal) to the node:
 
 For more information about downlink commands, see the [LHT65 temperature sensor user guide](https://www.dragino.com/downloads/downloads/LHT65/UserManual/LHT65_Temperature_Humidity_Sensor_UserManual_v1.3.pdf).
 
-#### Calibrate your WQS-LB
-
-Calibrate your WQS-LB water quality sensor before using it. You can calibrate your sensor using DoCommands.
-For more information about calibration, consult the [user manual](https://wiki.dragino.com/xwiki/bin/view/Main/User%20Manual%20for%20LoRaWAN%20End%20Nodes/WQS-LB--LoRaWAN_Water_Quality_Sensor_Transmitter_User_Manual/).
-
-##### Calibrate the pH probe
-
-The pH probe uses a thre-point calibration process:
-
-1. Wash the electrode with distilled water, then place it in a 9.18 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
-   ```json
-   {
-     "calibrate_ph": 9
-   }
-   ```
-2. Wash the electrode with distilled water, then place it in a 6.86 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
-   ```json
-   {
-     "calibrate_ph": 6
-   }
-   ```
-3. Wash the electrode with distilled water, then place it in a 4.01 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
-   ```json
-   {
-     "calibrate_ph": 4
-   }
-   ```
-
-##### Calibrate the electrical conductivity probe
-
-The EC probe uses a one-point calibration process. You can configure the EC probe in the following modes:
-
-- For K=1, to measure conductivity from 0-2000 μS/cm at a resolution of 1 μS/cm, wash the electrode with distilled water and place it in a 1413 μS/cm solution. Once the data stabilizes, send the following downlink:
-  ```json
-  {
-    "calibrate_ec": 1
-  }
-  ```
-
-- For K=10, to measure conductivity from 10-20000 μS/cm at a resolution of 10 μS/cm: wash the electrode with distilled water and place it in a 12.88 mS/cm solution. Once the data stabilizes, send the following downlink:
-  ```json
-  {
-    "calibrate_ec": 10
-  }
-  ```
-
-##### Calibrate the turbidity probe
-
-The turbidity probe uses a one-point calibration process:
-
-1. Prepare a 0 NTU, 200 NTU, 400 NTU, 600 NTU, 800 NTU, or 1000 NTU solution.
-2. Place the probe in the solution.
-3. Send the downlink with NTU value to your node:
-   ```json
-   {
-     "calibrate_t": <NTU value>
-   }
-   ```
-
-##### Calibrate the ORP probe
-
-The Oxidation-Reduction Potential (ORP) probe uses a two-point calibration process:
-
-1. Wash the electrode with distilled water and place the probe in a 86mV standard buffer.
-2. Once the data is stable, send the following downlink to the node:
-   ```json
-   {
-     "calibrate_orp" : 86
-   }
-   ```
-
-3. Wash the electrode with distilled water and place the probe in a 256mV standard buffer.
-4. Once the data is stable, send the following downlink to the node:
-   ```json
-   {
-     "calibrate_orp": 256
-   }
-   ```
 
 ### Configuration for `viam:lorawan:milesight-ct101` and `viam:lorawan:milesight-em310-tilt`
 

--- a/README.md
+++ b/README.md
@@ -1,65 +1,60 @@
 
 # LoRaWAN module
 
-## LoRaWAN Background
-LoRaWAN (Long Range Wide Area Network) is a low-power, long-range wireless protocol in which the **sensors** communicate over radio to **gateways** that receive the messages.
+LoRaWAN (Long Range Wide Area Network) is a low-power, long-range wireless protocol in which the **sensors** communicate over radio with **gateways**.
 
+For more, see the [the Viam documentation page](https://docs.viam.com/data-ai/capture-data/lorawan/).
 
-For more, see the [article on the Viam blog](https://www.viam.com/post/launch-lorawan-support-viam).
+## What's in this module?
 
-## What's in this module
 This Viam module provides models for LoRaWAN **sensors** (end devices/transmitters) as well as LoRaWAN **gateways** (receivers).
 
-The LoRaWAN **sensor** models allow registering a LoRaWAN sensor with a LoRaWAN gateway model. These models also implement Viam's Sensor GetReadings method by calling GetReadings on the gateway model and filtering the output to just the particular sensor's readings.
+The LoRaWAN **node** models allow registering a LoRaWAN node with a LoRaWAN gateway. These models also implement Viam's Sensor GetReadings method by calling GetReadings on the gateway model and filtering the output to just the particular sensor's readings.
 
-The LoRaWAN **gateway** models interface with a physical gateway device (such as the [Waveshare sx1302 LoRaWAN gateway HAT for Raspberry Pi](https://www.waveshare.com/wiki/SX1302_LoRaWAN_Gateway_HAT)) to pull all sensor readings from the gateway device and return them through Viam's Sensor [GetReadings](https://docs.viam.com/dev/reference/apis/components/sensor/#getreadings) method.
+The LoRaWAN **gateway** models interface with a physical gateway device (such as the [Waveshare SX1302 LoRaWAN gateway HAT for Raspberry Pi](https://www.waveshare.com/wiki/SX1302_LoRaWAN_Gateway_HAT)) to pull all sensor readings from the gateway device and return them through Viam's Sensor [GetReadings](https://docs.viam.com/dev/reference/apis/components/sensor/#getreadings) method.
 
 ## Example use
-A typical architecture will involve:
+A typical architecture involves:
 
-- a Raspberry Pi
-- an sx1302 gateway physically attached to the Raspberry Pi
+- a gateway physically attached to a machine -- either an HAT connected to a Raspberry Pi SBC or a machine with internal LoRaWAN radios
 - one or more LoRaWAN sensors physically located up to a couple miles away from the gateway
 
-The Raspberry Pi will be running viam-server, and the **Viam config** for this viam-server will include:
+The machine runs `viam-server`. The `viam-server` configuration must include:
 
-- a **gateway** model for the gateway device
-- a **sensor** model for **each** LoRaWAN sensor
+- a **board** model for the machine that hosts your gateway
+- a **gateway** model for the gateway
+- a **node** model for **each** LoRaWAN node
 
-## LoRaWAN sensor models provided
-This module provides the following models for **specific** LoRaWAN sensors:
+## Supported LoRaWAN nodes
+
+This module provides models for the following LoRaWAN node hardware:
 
 - `viam:lorawan:dragino-LHT65N`: [Dragino LHT65N](https://www.amazon.com/LHT65N-LoRaWAN-Temperature-Humidity-Sensor/dp/B0BL7X7X6C) temperature and humidity sensor.
 - `viam:lorawan:dragino-WQSLB`: [Dragino WQS-LB](https://www.dragino.com/products/water-air-quality-sensor/item/345-wqs-lb.html) water quality sensor
-- `viam:lorawan:milesight-ct101`: [Milesight ct101](https://www.milesight.com/iot/product/lorawan-sensor/ct10x) current transformer
-- `viam:lorawan:milesight-em310-tilt`: [Milesight em310 tilt sensor](https://www.milesight.com/iot/product/lorawan-sensor/em310-tilt)
+- `viam:lorawan:milesight-ct101`: [Milesight CT101](https://www.milesight.com/iot/product/lorawan-sensor/ct10x) current transformer
+- `viam:lorawan:milesight-em310-tilt`: [Milesight EM310-TILT sensor](https://www.milesight.com/iot/product/lorawan-sensor/em310-tilt)
+- `viam:lorawan:node`: a generic model that can be used with any LoRaWAN sensor that meets the following criteria:
+  - Class A
+  - supports the `US915` or `EU868` frequency bands
+  - uses LoRaWAN MAC specification version 1.0.3
 
-This module also provides a **generic** model that can be used with any LoRaWAN sensor that meets the criteria, but requires inputting slightly more via the config attributes:
+See the configuration options for each of these models below.
 
-- `node`: Any LoRaWAN sensor that is Class A, supports either the US915 or EU868 frequency band, and uses LoRaWAN MAC specification version 1.0.3
+## Supported LoRaWAN gateways
 
-See below for the Viam configuration for each of these models.
+This module provides models for the following LoRaWAN gateway hardware:
 
-## LoRaWAN gateway models provided
-This module provides the following models for **specific** LoRaWAN gateways:
-
-- `viam:lorawan:sx1302-waveshare-hat`: [Waveshare LoRaWAN sx1302 gateway HAT](https://www.waveshare.com/wiki/SX1302_LoRaWAN_Gateway_HAT)
-- `viam:lorawan:rak7391`: [rak7391 Wisgate Connect](https://docs.rakwireless.com/product-categories/wisgate/rak7391/overview/)
-
-This module also provides a **sx1302 generic** model that can be used with other sx1302 HATs:
-
-- `viam:lorawan:sx1302-hat-generic`: Other sx1302 LoRaWAN gateway HATs
+- `viam:lorawan:sx1302-waveshare-hat`: [Waveshare LoRaWAN SX1302 gateway HAT](https://www.waveshare.com/wiki/SX1302_LoRaWAN_Gateway_HAT)
+- `viam:lorawan:rak7391`: [RAK7391 Wisgate Connect](https://docs.rakwireless.com/product-categories/wisgate/rak7391/overview/)
+- `viam:lorawan:sx1302-hat-generic`: a generic model that can be used with all other peripherals built using the SX1302 or SX1303 chips
 
 See below for the Viam configuration for each of these models.
 
-## Configuration for LoRaWAN sensor models
+## Configuration for LoRaWAN nodes
 
-### Configuration for `viam:lorawan:dragino-LHT65N` and `viam:lorawan:dragino-WQSLB`
+### Configuration for `viam:lorawan:dragino-LHT65N` and `viam:lorawan:dragino-WQS-LB`
 
-If using a WSQ-LB, be sure to calibrate the sensor using the instructions below.
-Submerge the WQS-LB probes in liquid to obtain valid readings.
-
-#### Quick examples
+#### Examples
 
 Example OTAA node configuration:
 
@@ -68,61 +63,67 @@ Example OTAA node configuration:
   "join_type": "OTAA",
   "dev_eui": <string>,
   "app_key": <string>,
-  "gateways": [<string gatewayname>]
+  "gateways": [<string>]
 }
 ```
 
 Example ABP node configuration:
+
 ```json
 {
   "join_type": "ABP",
   "dev_addr": <string>,
   "app_s_key": <string>,
   "network_s_key": <string>,
-  "gateways": [<string gatewayname>]
+  "gateways": [<string>]
 }
 ```
-#### General Attributes
+
+#### General attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| join_type | string | no | "OTAA" | Join type ("OTAA" or "ABP") |
-| uplink_interval_mins | float64 | no | 20 | Desired interval in minutes between uplink messages sent by the node. The sensor will send a set interval downlink if configured. |
-| gateways | []string | yes | - | gateways the node can send data to. Can also be in the `Depends on` drop down. |
+| `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
+| `uplink_interval_mins` | float64 | no | 20.0 | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
+| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
 
 #### OTAA Attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| dev_eui | string | yes | - | Device EUI (8 bytes in hex). Unique indentifer for the node. Can be found printed on your device or on the box.|
-| app_key | string | yes | - | Application Key (16 bytes in hex). Used to securely join the network. Unique to the specific device, can be found on the box. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Required for OTAA activation protocol. Found in the device datasheet. |
 
-#### ABP Attributes
+#### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| dev_addr | string | yes | - | Device Address (4 bytes in hex). Used to identify uplink messages. Can normally be found on datasheet or box. |
-| app_s_key | string | yes | - | Application Session Key (16 bytes in hex) Used to decrypt uplink messages. Default can normally be found on the node's datasheet or box. |
-| network_s_key | string | yes | - | Network Session Key (16 bytes in hex) Used to decypt uplink messages. Default can normally be found on the node's datasheet or box. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+
+NOTE: If using a WQS-LB, be sure to calibrate the sensor using the instructions below.
 
 #### DoCommand
 
-The dragino model uses DoCommand to send downlinks to sensors from the gateway. The sensor may indicate when it has received an uplink or downlink, e.g. a blue light when it sends an uplink and purple light when it receives a downlink.
-**The sensor must already be connected to Viam (i.e., "Live" on app.viam.com) for downlink requests to work.**
+You can use DoCommand to send downlink requests to nodes connected to your gateway.
+Connected nodes indicate communication using a blue light for uplinks and purple light for downlinks.
 
 ##### Update the uplink interval
 
-This command will update the interval the dragino sends data at. This can also be set via the 'uplink_interval_mins' field in the config.
+Update the interval the node sends data at:
 
 ```json
 {
-  "set_interval": 1.0
+  "set_interval": <float64>
 }
 ```
 
+Alternatively, set the interval using `uplink_interval_mins` in the node configuration.
+
 ##### Restart the device
 
-This command will restart the dragino sensor, triggering a new join request.
+Restart the node, triggering a new join request:
 
 
 ```json
@@ -133,100 +134,106 @@ This command will restart the dragino sensor, triggering a new join request.
 
 ##### Send a generic downlink
 
-This command will send a generic downlink payload to the gateway. the string is expected to be a set of bytes in hex. See the [LHT64 temperature sensor user guide](https://www.dragino.com/downloads/downloads/LHT65/UserManual/LHT65_Temperature_Humidity_Sensor_UserManual_v1.3.pdf) for other downlink commands.
+Send a generic downlink payload (in hexadecimal) to the node:
 
 ```json
 {
-  "send_downlink": "<BYTESINHEX>"
+  "send_downlink": <string>
 }
 ```
 
-#### Calibrate your `dragino-WQS-LB`
-The WQS-LB water quality sensor should be calibrated upon first use. The calibration can be completed using do commands on the UI.
-For more information about calibrating the devices, consult the [user manual.](https://wiki.dragino.com/xwiki/bin/view/Main/User%20Manual%20for%20LoRaWAN%20End%20Nodes/WQS-LB--LoRaWAN_Water_Quality_Sensor_Transmitter_User_Manual/)
+For more information about downlink commands, see the [LHT65 temperature sensor user guide](https://www.dragino.com/downloads/downloads/LHT65/UserManual/LHT65_Temperature_Humidity_Sensor_UserManual_v1.3.pdf).
 
-##### Calibrate the PH Probe
-The PH probe uses a 3 point calibration, follow the below steps to calibrate:
-1. Wash the electrode with distilled water and place it in a 9.18 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
-```json
-{
-  "calibrate_ph": 9
-}
-```
-2. Wash the electrode with distilled water and place it in a 6.86 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
-```json
-{
-  "calibrate_ph": 6
-}
-```
-3. Wash the electrode with distilled water and place it in a 4.01 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
-```json
-{
-  "calibrate_ph": 4
-}
-```
+#### Calibrate your WQS-LB
+
+Calibrate your WQS-LB water quality sensor before using it. You can calibrate your sensor using DoCommands.
+For more information about calibration, consult the [user manual](https://wiki.dragino.com/xwiki/bin/view/Main/User%20Manual%20for%20LoRaWAN%20End%20Nodes/WQS-LB--LoRaWAN_Water_Quality_Sensor_Transmitter_User_Manual/).
+
+##### Calibrate the pH probe
+
+The pH probe uses a thre-point calibration process:
+
+1. Wash the electrode with distilled water, then place it in a 9.18 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
+   ```json
+   {
+     "calibrate_ph": 9
+   }
+   ```
+2. Wash the electrode with distilled water, then place it in a 6.86 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
+   ```json
+   {
+     "calibrate_ph": 6
+   }
+   ```
+3. Wash the electrode with distilled water, then place it in a 4.01 standard buffer solution. Once the data stabilizes, send the following downlink to the node:
+   ```json
+   {
+     "calibrate_ph": 4
+   }
+   ```
 
 ##### Calibrate the electrical conductivity probe
-The EC probe uses one-point calibration.
 
-If K=1 (1-2000 uS/cm) use the following steps to calibrate:
-1. Wash the electrode with distilled water and place it in a 1413 uS/cm solution
-2. When data is stable, send the following downlink:
-```json
-{
-  "calibrate_ec": 1
-}
-```
+The EC probe uses a one-point calibration process. You can configure the EC probe in the following modes:
 
-If K=10 (10-20000 mS/cm), use the following steps to calibrate:
-1. Wash the electrode with distilled water and place it in a 12.88 mS/cm solution
-2. When data is stable, send the following downlink:
-```json
-{
-  "calibrate_ec": 10
-}
-```
+- For K=1, to measure conductivity from 0-2000 μS/cm at a resolution of 1 μS/cm, wash the electrode with distilled water and place it in a 1413 μS/cm solution. Once the data stabilizes, send the following downlink:
+  ```json
+  {
+    "calibrate_ec": 1
+  }
+  ```
+
+- For K=10, to measure conductivity from 10-20000 μS/cm at a resolution of 10 μS/cm: wash the electrode with distilled water and place it in a 12.88 mS/cm solution. Once the data stabilizes, send the following downlink:
+  ```json
+  {
+    "calibrate_ec": 10
+  }
+  ```
 
 ##### Calibrate the turbidity probe
-The turbidity probe uses a one-point calibration, use the following steps to calibrate:
 
-1. Prepare a 0 NTU, 200 NTU, 400 NTU, 600 NTU, 800 NTU, or 1000 NTU solution
-2. Place the probe in the solution
+The turbidity probe uses a one-point calibration process:
+
+1. Prepare a 0 NTU, 200 NTU, 400 NTU, 600 NTU, 800 NTU, or 1000 NTU solution.
+2. Place the probe in the solution.
 3. Send the downlink with NTU value to your node:
-```json
-{
-  "calibrate_t": <NTU value>
-}
-```
+   ```json
+   {
+     "calibrate_t": <NTU value>
+   }
+   ```
 
-##### Calibrate the orp probe
-The orp probe use 2-point calibration. To calibrate, follow these steps:
-1. Wash the electrode with distilled water and place it in a 86mV standard buffer.
+##### Calibrate the ORP probe
+
+The Oxidation-Reduction Potential (ORP) probe uses a two-point calibration process:
+
+1. Wash the electrode with distilled water and place the probe in a 86mV standard buffer.
 2. Once the data is stable, send the following downlink to the node:
-```json
-{
-  "calibrate_orp" : 86
-}
-```
+   ```json
+   {
+     "calibrate_orp" : 86
+   }
+   ```
 
-3. Wash with distilled water again, and place probe in a 256mV standard buffer.
+3. Wash the electrode with distilled water and place the probe in a 256mV standard buffer.
 4. Once the data is stable, send the following downlink to the node:
-```json
-{
-  "calibrate_orp": 256
-}
-```
+   ```json
+   {
+     "calibrate_orp": 256
+   }
+   ```
 
 ### Configuration for `viam:lorawan:milesight-ct101` and `viam:lorawan:milesight-em310-tilt`
 
-#### Quick examples
+#### Examples
+
 Example OTAA node configuration:
 
 ```json
 {
   "join_type": "OTAA",
-  "dev_eui": "0123456789ABCDEF",
-  "gateways": ["gateway-1"]
+  "dev_eui": <string>,
+  "gateways": [<string>]
 }
 ```
 
@@ -235,8 +242,8 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_addr": "01234567",
-  "gateways": ["gateway-1"]
+  "dev_addr": <string>,
+  "gateways": [<string>]
 }
 ```
 
@@ -244,43 +251,47 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| join_type | string | no | "OTAA" | Join type ("OTAA" or "ABP") |
-| uplink_interval_mins | float64 | no | **10** for the ct101 and **1080** for the em310-tilt | Desired interval in minutes between uplink messages sent by the node. The sensor will send a set interval downlink if configured. |
-| gateways | []string | yes | - | gateways the node can send data to. Can also be in the `Depends on` drop down. |
+| `decoder_path` | string | yes | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
+| `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
+| `uplink_interval_mins` | float64 | no | Defaults: `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
+| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
+| `fport` | string | no | `01` (`0x01`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. <br> On supported Milesight models, defaults to `"55"` (equivalent to `0x55`). |
 
 #### OTAA Attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| dev_eui | string | yes | - | Device EUI (8 bytes in hex). Unique indentifer for the node. Can be found printed on your device or on the box.|
-| app_key | string | no | 5572404C696E6B4C6F52613230313823 | Application Key (16 bytes in hex). Used to securely join the network. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Required for OTAA activation protocol. Found in the device datasheet. |
 
-#### ABP Attributes
+#### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| dev_addr | string | yes | - | Device Address (4 bytes in hex). Used to identify uplink messages. Can normally be found on datasheet or box. |
-| app_s_key | string | no | 5572404C696E6B4C6F52613230313823 | Application Session Key (16 bytes in hex) Used to decrypt uplink messages. |
-| network_s_key | string | no | 5572404C696E6B4C6F52613230313823 | Network Session Key (16 bytes in hex) Used to decypt uplink messages. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### DoCommand
 
-The Milesight models use DoCommands to send downlinks to sensors from the gateway.
-**The sensor must already be connected to Viam (i.e., "Live" on app.viam.com) for downlink requests to work.**
+You can use DoCommand to send downlink requests to nodes connected to your gateway.
 
 ##### Update the uplink interval
 
-This command will update the interval the milesight sends data at. This can also be set via the 'uplink_interval_mins' field in the config.
+Update the interval the node sends data at:
 
 ```json
 {
-  "set_interval": 1.0
+  "set_interval": <float64>
 }
 ```
 
+Alternatively, set the interval using `uplink_interval_mins` in the node configuration.
+
 ##### Restart the device
 
-This command will restart the milesight sensor, triggering a new join request.
+Restart the node, triggering a new join request:
+
 
 ```json
 {
@@ -290,28 +301,28 @@ This command will restart the milesight sensor, triggering a new join request.
 
 ##### Send a generic downlink
 
-This command will send a generic downlink payload to the gateway. The string is expected to be a set of bytes in hex. See the [em310 tilt sensor user guide](https://resource.milesight.com/milesight/iot/document/em310-tilt-user-guide-en.pdf) or the [ct101 user guide](https://resource.milesight.com/milesight/iot/document/ct10x-user-guide-en.pdf) for their respective downlink commands.
+Send a generic downlink payload (in hexadecimal) to the node:
 
 ```json
 {
-  "send_downlink": "<BYTESINHEX>"
+  "send_downlink": <string>
 }
 ```
 
+For more information about downlink commands, see the [EM310-TILT sensor user guide](https://resource.milesight.com/milesight/iot/document/em310-tilt-user-guide-en.pdf) or the [CT101 user guide](https://resource.milesight.com/milesight/iot/document/ct10x-user-guide-en.pdf).
+
 ### Configuration for `viam:lorawan:node`
 
-#### Quick examples
+#### Examples
 
 Example OTAA node configuration:
 
 ```json
 {
   "join_type": "OTAA",
-  "decoder_path": "/path/to/decoder.js",
-  "dev_eui": "0123456789ABCDEF",
-  "app_key": "0123456789ABCDEF0123456789ABCDEF",
-  "uplink_interval_mins": 10,
-  "gateways": ["gateway-1"]
+  "dev_eui": <string>,
+  "app_key": <string>,
+  "gateways": [<string>],
 }
 ```
 
@@ -320,13 +331,10 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "decoder_path": "/path/to/decoder.js",
-  "dev_addr": "01234567",
-  "app_s_key": "0123456789ABCDEF0123456789ABCDEF",
-  "network_s_key": "0123456789ABCDEF0123456789ABCDEF",
-  "uplink_interval_mins": 10,
-  "gateways": ["gateway-1"],
-  "fport": "55"
+  "dev_addr": <string>,
+  "app_s_key": <string>,
+  "network_s_key": <string>,
+  "gateways": [<string>],
 }
 ```
 
@@ -334,59 +342,116 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| decoder_path | string | yes | - | Path to the payload decoder script. This must be a .js file. If the device provides multiple decoder files, use the chirpstack version. |
-| join_type | string | no | "OTAA" | Join type ("OTAA" or "ABP"). |
-| uplink_interval_mins | float64 | yes | - | Expected interval between uplink messages sent by the node. The default can be found on the datasheet and can be modified using device specific software. |
-| gateways | []string | yes | - | gateways the node can send data to. Can also be in the `Depends on` drop down. |
-| fport | string | no | - | port (in hex) to send downlinks to the device. |
-
-The node registers itself with the gateway so the gateway will recognize messages from the node.
+| `decoder_path` | string | yes | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
+| `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
+| `uplink_interval_mins` | float64 | no | Defaults: `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
+| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
+| `fport` | string | no | `55` (aka `0x55`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
 
 #### OTAA Attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| dev_eui | string | yes | - | Device EUI (8 bytes in hex). Unique indentifer for the node. Can be found printed on your device or on the box.|
-| app_key | string | yes | - | Application Key (16 bytes in hex). Used to securely join the network. The default can normally be found in the node's datasheet. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Required for OTAA activation protocol. Found in the device datasheet. |
 
-#### ABP Attributes
+#### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| dev_addr | string | yes | - | Device Address (4 bytes in hex). Used to identify uplink messages. Can normally be found on datasheet or box. |
-| app_s_key | string | yes | - | Application Session Key (16 bytes in hex) Used to decrypt uplink messages. Default can normally be found on the node's datasheet or box. |
-| network_s_key | string | yes | - | Network Session Key (16 bytes in hex) Used to decypt uplink messages. Default can normally be found on the node's datasheet or box. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+
 
 #### DoCommand
 
-The sensor node model uses DoCommands to send downlinks to sensors from the gateway.
+You can use DoCommand to send downlink requests to nodes connected to your gateway.
 
 ##### Send a downlink
 
-This command will send a generic downlink payload to the gateway. The string is expected to be a set of bytes in hex.
+Send a generic downlink payload (in hexadecimal) to the node:
 
 ```json
 {
-  "send_downlink": "<BYTESINHEX>"
+  "send_downlink": <string>
 }
 ```
 
-
 ## Configuration for LoRaWAN gateway models
 
-### Configuration for `viam:lorawan:sx1302-hat-generic`
+### Configuration for `viam:lorawan:sx1302-waveshare-hat`
 
-Note: The gpio pins MUST be set to the gpio pin numbers on your board connected to the reset and power-enable pins of the sx1302 hat to avoid a 15-minute reset loop.
-
-#### Quick example
+#### Example
 
 ```json
 {
-    "board": "rpi",
-    "spi_bus": 0,
-    "reset_pin": int,
-    "power_en_pin": int,
-    "region_code": "US915"
+    "board": <string>,
+    "spi_bus": <int>,
+    "region_code": <string>
+}
+```
+
+#### Attributes
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that the peripheral is connected to. Used for GPIO pin control. |
+| `spi_bus` | int | no | 0 | SPI bus number used to connect the gateway peripheral. Options: [`0`, `1`] |
+| `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |
+
+### Configuration for `viam:lorawan:rak7391`
+
+Before configuring the RAK7391, follow [the manual](https://docs.rakwireless.com/product-categories/software-apis-and-libraries/rakpios/quickstart) to install RAKPiOS and connect to the Internet.
+
+You can run the following command to discover where the concentrators are connected:
+
+`docker run --privileged --rm rakwireless/udp-packet-forwarder find_concentrator`
+
+Use the returned SPI or serial paths in your viam configuration.
+
+
+#### Quick Example
+
+```json
+{
+  "pcie1": {
+    "serial_path": <string>,
+    "spi_bus": <int>
+  },
+  "pcie2": {
+    "serial_path": <string>,
+    "spi_bus": <int>
+  },
+  "board": <string>
+}
+```
+
+#### Attributes
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that represents the Raspberry Pi Compute Module inside the RAK7391. Used for GPIO pin control. |
+| `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |
+| `pcie1` | config | no | - | PCIe configuration for concentrator connected to PCIe slot 1: <br> <ul><li>`spi_bus` (integer) (Optional): SPI bus that the concentrator is connected to, if connected through SPI. </li><li>`serial_path` (string) (Optional): Serial path that the concentrator is mounted at, if connected through USB. </li></ul> |
+| `pcie2` |config | no | - | PCIe configuration for concentrator connected to PCIe slot 2: <br> <ul><li>`spi_bus` (integer) (Optional): SPI bus that the concentrator is connected to, if connected through SPI. </li><li>`serial_path` (string) (Optional): Serial path that the concentrator is mounted at, if connected through USB. </li></ul> |
+
+
+### Configuration for `viam:lorawan:sx1302-hat-generic`
+
+This generic model can be used for any peripheral built using the SX1302 or SX1303 chips.
+
+Note: To avoid a 15-minute reset loop, set the GPIO pins to the GPIO pin numbers that connect your board to the reset and power-enable pins of the HAT.
+
+#### Example
+
+```json
+{
+    "board": <string>,
+    "spi_bus": <int>,
+    "reset_pin": <int>,
+    "power_en_pin": <int>,
+    "region_code": <string>
 }
 ```
 
@@ -396,82 +461,27 @@ The following attributes are available for `viam:lorawan:sx1302-hat-generic` sen
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| board | string | yes | - | Name of the board connected to the HAT. The board communicates with the gateway through SPI |
-| reset_pin | int | yes | - | GPIO pin number for sx1302 reset pin |
-| spi_bus | int | no | 0 | SPI bus number  |
-| power_en_pin | int | no | - | GPIO pin number for the power enable pin |
-| region_code | string | no | US915 | frequency region of your gateway (US915 or EU868) |
-
-### Configuration for `viam:lorawan:sx1302-waveshare-hat`
-
-#### Quick example
-
-```json
-{
-    "board": "rpi",
-    "spi_bus": 0,
-    "region_code": "US915"
-}
-```
-
-#### Attributes
-
-| Name | Type | Required | Default | Description |
-|------|------|----------|---------|-------------|
-| board | string | yes | - | Name of the board connected to the HAT. The board communicates with the gateway through SPI |
-| spi_bus | int | no | 0 | SPI bus number (0 or 1 on a raspberry pi) |
-| region_code | string | no | US915 | frequency region of your gateway (US915 or EU868) |
-
-### Configuration for`viam:lorawan:rak7391`
-
-Before configuring the rak7391, follow [the manual](https://docs.rakwireless.com/product-categories/software-apis-and-libraries/rakpios/quickstart) to install RAKPiOS and connect to the device.
-
-You can run the following command to discover where the concentrators are connected:
-
-`docker run --privileged --rm rakwireless/udp-packet-forwarder find_concentrator`
-
-Use the returned spi or serial paths in your viam configuration.
-
-
-#### Quick Example
-
-```json
-{
-  "pcie1": {
-    "serial_path": <serial_path>
-  },
-  "pcie2": {
-    "serial_path": <serial_path>
-  },
-  "board": <string-boardname>
-}
-```
-
-#### Attributes
-
-| Name | Type | Required | Default | Description |
-|------|------|----------|---------|-------------|
-| board | string | yes | - | Name of the raspberry pi board in your RAK |
-| region_code | string | no | US915 | frequency region of your gateway (US915 or EU868) |
-| pcie1 | config | no | - | info about the concentrator connected to the pcie1 slot of the RAK |
-| pcie2 |config | no | - | info about the concentrator connected to the pcie2 slot of the RAK |
-
-
-The following attributes are available for the pcies:
-| Name | Type | Required | Default | Description |
-|------|------|----------|---------|-------------|
-| spi_bus | int | no | 0 | SPI bus number (0 or 1 on a raspberry pi), for concentrators are connected through SPI |
-| serial_path | int | no | 0 | serial path concentrator is connected to, if connected through USB |
+| `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that the peripheral is connected to. Used for GPIO pin control. |
+| `reset_pin` | int | yes | - | GPIO pin used for peripheral reset. |
+| `spi_bus` | int | no | 0 | SPI bus number used to connect the gateway peripheral. Options: [`0`, `1`]  |
+| `power_en_pin` | int | no | - | GPIO pin used for peripheral power enable. |
+| `path` | string | no | - | Serial path that the peripheral is mounted at, if connected through USB. |
+| `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |
 
 
 ## Troubleshooting
-When the gateway is properly configured, the pwr LED will be solid red and the rx and tx LEDs will be blinking red.
+
+When the gateway is properly configured:
+
+- the `pwr` LED will light up solid red
+- the `rx` and `tx` LEDs will blink red
 
 It may take several minutes after starting the module to start receiving data, especially if your node transmits on more than 8 frequency channels.
-The gateway will log info logs when it has received a join request or data uplink.
 
-The gateway communicates through SPI, so [ensure that SPI in enabled on the Pi](https://docs.viam.com/operate/reference/prepare/rpi-setup/#enable-communication-protocols).
+The gateway communicates through SPI, so [ensure that SPI in enabled on your machine](https://docs.viam.com/operate/reference/prepare/rpi-setup/#enable-communication-protocols).
 
-To avoid capturing duplicate data, set the data capture frequency equal to or less than the expected uplink interval.
+The gateway will log `info` logs when a device sends a join request or uplink.
 
-If you see the error `ERROR: Failed to set SX1250_0 in STANDBY_RC mode` in logs, unplug the Raspberry Pi for a few minutes and then try again.
+To avoid capturing duplicate data, set the data capture frequency longer than or equal to the expected uplink interval.
+
+If you see the error `ERROR: Failed to set SX1250_0 in STANDBY_RC mode` in logs, unplug the machine for a few minutes, then try again.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Example ABP node configuration:
 | `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
 | `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
 | `uplink_interval_mins` | float64 | no | 20.0 | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
-| `fport` | string | no | `01` (`0x01`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
 
 
 #### OTAA Attributes

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Example ABP node configuration:
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
-| `decoder_path` | string | no | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. |
+| `decoder_path` | string | yes | - | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. |
 | `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
 | `uplink_interval_mins` | float64 | no | Defaults: `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
 | `fport` | string | no | - | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 
 # LoRaWAN module
 
-LoRaWAN (Long Range Wide Area Network) is a low-power, long-range wireless protocol in which the **sensors** communicate over radio with **gateways**.
+LoRaWAN (Long Range Wide Area Network) is a low-power, long-range wireless protocol in which the **nodes** communicate over radio with **gateways**.
 
 For more, see the [the Viam documentation page](https://docs.viam.com/data-ai/capture-data/lorawan/).
 
 ## What's in this module?
 
-This Viam module provides models for LoRaWAN **sensors** (end devices/transmitters) as well as LoRaWAN **gateways** (receivers).
+This Viam module provides models for LoRaWAN **nodes** (end devices/transmitters) as well as LoRaWAN **gateways** (receivers).
 
-The LoRaWAN **node** models allow registering a LoRaWAN node with a LoRaWAN gateway. These models also implement Viam's Sensor GetReadings method by calling GetReadings on the gateway model and filtering the output to just the particular sensor's readings.
+The LoRaWAN **node** models allow registering a LoRaWAN node with a LoRaWAN gateway. These models also implement Viam's Sensor GetReadings method by calling GetReadings on the gateway model and filtering the output to just the particular nodes's readings.
 
 The LoRaWAN **gateway** models interface with a physical gateway device (such as the [Waveshare SX1302 LoRaWAN gateway HAT for Raspberry Pi](https://www.waveshare.com/wiki/SX1302_LoRaWAN_Gateway_HAT)) to pull all sensor readings from the gateway device and return them through Viam's Sensor [GetReadings](https://docs.viam.com/dev/reference/apis/components/sensor/#getreadings) method.
 
@@ -17,7 +17,7 @@ The LoRaWAN **gateway** models interface with a physical gateway device (such as
 A typical architecture involves:
 
 - a gateway physically attached to a machine -- either an HAT connected to a Raspberry Pi SBC or a machine with internal LoRaWAN radios
-- one or more LoRaWAN sensors physically located up to a couple miles away from the gateway
+- one or more LoRaWAN nodes physically located up to a couple miles away from the gateway
 
 The machine runs `viam-server`. The `viam-server` configuration must include:
 
@@ -33,7 +33,7 @@ This module provides models for the following LoRaWAN node hardware:
 - `viam:lorawan:dragino-WQSLB`: [Dragino WQS-LB](https://www.dragino.com/products/water-air-quality-sensor/item/345-wqs-lb.html) water quality sensor
 - `viam:lorawan:milesight-ct101`: [Milesight CT101](https://www.milesight.com/iot/product/lorawan-sensor/ct10x) current transformer
 - `viam:lorawan:milesight-em310-tilt`: [Milesight EM310-TILT sensor](https://www.milesight.com/iot/product/lorawan-sensor/em310-tilt)
-- `viam:lorawan:node`: a generic model that can be used with any LoRaWAN sensor that meets the following criteria:
+- `viam:lorawan:node`: a generic model that can be used with any LoRaWAN node that meets the following criteria:
   - Class A
   - supports the `US915` or `EU868` frequency bands
   - uses LoRaWAN MAC specification version 1.0.3
@@ -309,7 +309,7 @@ Send a generic downlink payload (in hexadecimal) to the node:
 }
 ```
 
-For more information about downlink commands, see the [EM310-TILT sensor user guide](https://resource.milesight.com/milesight/iot/document/em310-tilt-user-guide-en.pdf) or the [CT101 user guide](https://resource.milesight.com/milesight/iot/document/ct10x-user-guide-en.pdf).
+For more information about downlink commands, see the [EM310-TILT user guide](https://resource.milesight.com/milesight/iot/document/em310-tilt-user-guide-en.pdf) or the [CT101 user guide](https://resource.milesight.com/milesight/iot/document/ct10x-user-guide-en.pdf).
 
 ### Configuration for `viam:lorawan:node`
 
@@ -457,8 +457,6 @@ Note: To avoid a 15-minute reset loop, set the GPIO pins to the GPIO pin numbers
 
 #### Attributes
 
-The following attributes are available for `viam:lorawan:sx1302-hat-generic` sensors:
-
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that the peripheral is connected to. Used for GPIO pin control. |
@@ -467,7 +465,6 @@ The following attributes are available for `viam:lorawan:sx1302-hat-generic` sen
 | `power_en_pin` | int | no | - | GPIO pin used for peripheral power enable. |
 | `path` | string | no | - | Serial path that the peripheral is mounted at, if connected through USB. |
 | `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |
-
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ Example ABP node configuration:
 | `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
 | `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
 | `uplink_interval_mins` | float64 | no | `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
-| `fport` | string | no | `55` (`0x55`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
 
 #### OTAA Attributes
 

--- a/README.md
+++ b/README.md
@@ -187,15 +187,15 @@ Example ABP node configuration:
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | no | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | no | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | yes | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
+| `app_key` | string | no | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
 
 #### DoCommand

--- a/README.md
+++ b/README.md
@@ -361,10 +361,19 @@ Use the returned SPI or serial paths in your viam configuration.
 |------|------|----------|---------|-------------|
 | `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that represents the Raspberry Pi Compute Module inside the RAK7391. Used for GPIO pin control. |
 | `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |
-| `pcie1` | config | no | - | PCIe configuration for concentrator connected to PCIe slot 1: <br> <ul><li>`spi_bus` (integer) (Optional): SPI bus that the concentrator is connected to, if connected through SPI. </li><li>`serial_path` (string) (Optional): Serial path that the concentrator is mounted at, if connected through USB. </li></ul> |
-| `pcie2` |config | no | - | PCIe configuration for concentrator connected to PCIe slot 2: <br> <ul><li>`spi_bus` (integer) (Optional): SPI bus that the concentrator is connected to, if connected through SPI. </li><li>`serial_path` (string) (Optional): Serial path that the concentrator is mounted at, if connected through USB. </li></ul> |
+| `pcie1` | config | no | - | PCIe configuration for concentrator connected to PCIe slot 1. For information about configuration of this attribute, see [PCIe field attributes](#pcie-field-attributes) below. |
+| `pcie2` |config | no | - | PCIe configuration for concentrator connected to PCIe slot 2. For information about configuration of this attribute, see [PCIe field attributes](#pcie-field-attributes) below. |
 
 You must specify at least one PCIe configuration.
+
+#### PCIe field attributes
+
+The PCIe configuration fields support the following attributes:
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `spi_bus` | integer | no | - | SPI bus that the concentrator is connected to, if connected through SPI. |
+| `serial_path` | string | no | - | Serial path that the concentrator is mounted at, if connected through USB. |
 
 ### Configuration for `viam:lorawan:sx1302-hat-generic`
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Example ABP node configuration:
 | `decoder_path` | string | yes | - | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. |
 | `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
 | `uplink_interval_mins` | float64 | no | Defaults: `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
-| `fport` | string | no | - | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
+| `fport` | string | no | - | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. Required to send downlinks using a DoCommand. |
 
 #### OTAA Attributes
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Example OTAA node configuration:
 ```json
 {
   "join_type": "OTAA",
-  "dev_eui": <string>,
-  "app_key": <string>,
+  "dev_addr": <string>,
+  "app_s_key": <string>,
+  "network_s_key": <string>,
   "gateways": [<string>]
 }
 ```
@@ -74,9 +75,8 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_addr": <string>,
-  "app_s_key": <string>,
-  "network_s_key": <string>,
+  "dev_eui": <string>,
+  "app_key": <string>,
   "gateways": [<string>]
 }
 ```
@@ -96,16 +96,16 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Required for OTAA activation protocol. Found in the device datasheet. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
 NOTE: If using a WQS-LB, be sure to calibrate the sensor using the instructions below.
 
@@ -159,7 +159,7 @@ Example OTAA node configuration:
 ```json
 {
   "join_type": "OTAA",
-  "dev_eui": <string>,
+  "dev_addr": <string>,
   "gateways": [<string>]
 }
 ```
@@ -169,7 +169,7 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_addr": <string>,
+  "dev_eui": <string>,
   "gateways": [<string>]
 }
 ```
@@ -188,16 +188,17 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | yes | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Required for OTAA activation protocol. Found in the device datasheet. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | yes | `5572404C696E6B4C6F52613230313823` | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | `5572404C696E6B4C6F52613230313823` | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
+
 
 #### DoCommand
 
@@ -247,8 +248,9 @@ Example OTAA node configuration:
 ```json
 {
   "join_type": "OTAA",
-  "dev_eui": <string>,
-  "app_key": <string>,
+  "dev_addr": <string>,
+  "app_s_key": <string>,
+  "network_s_key": <string>,
   "gateways": [<string>],
 }
 ```
@@ -258,9 +260,8 @@ Example ABP node configuration:
 ```json
 {
   "join_type": "ABP",
-  "dev_addr": <string>,
-  "app_s_key": <string>,
-  "network_s_key": <string>,
+  "dev_eui": <string>,
+  "app_key": <string>,
   "gateways": [<string>],
 }
 ```
@@ -279,17 +280,16 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
-| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Required for OTAA activation protocol. Found in the device datasheet. |
+| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
+| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
+| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
 
 #### ABP attributes
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `dev_addr` | string | yes | - | 32-bit hexadecimal **device address** used to identify this device in LoRaWAN messages. Found in the device datasheet or in device packaging. |
-| `app_s_key` | string | yes | - | 128-bit hexadecimal **application session key** used to decrypt messages containing application data.  Found in the device datasheet or in device packaging. |
-| `network_s_key` | string | yes | - | 128-bit hexadecimal **network session key** used to decrypt network management messages. Found in the device datasheet or in device packaging. |
-
+| `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
+| `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
 #### DoCommand
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,12 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
+| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
+| `decoder_path` | string | no | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
 | `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
 | `uplink_interval_mins` | float64 | no | 20.0 | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
-| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
+| `fport` | string | no | `01` (`0x01`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
+
 
 #### OTAA Attributes
 
@@ -251,11 +254,11 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `decoder_path` | string | yes | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
-| `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
-| `uplink_interval_mins` | float64 | no | Defaults: `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
 | `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
-| `fport` | string | no | `01` (`0x01`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. <br> On supported Milesight models, defaults to `"55"` (equivalent to `0x55`). |
+| `decoder_path` | string | no | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
+| `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
+| `uplink_interval_mins` | float64 | no | `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
+| `fport` | string | no | `55` (`0x55`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
 
 #### OTAA Attributes
 
@@ -342,11 +345,11 @@ Example ABP node configuration:
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `decoder_path` | string | yes | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
+| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
+| `decoder_path` | string | no | (see description) | Path to a Javascript **decoder script** used to interpret data transmitted from the node. You can use a local path on your device or an HTTP(S) URL that points to a file on a remote server. If the decoder script provides multiple implementations, uses the Chirpstack version. Not compatible with The Things Network decoders. Defaults to the latest decoder published by the manufacturer on GitHub. |
 | `join_type` | string | no | `OTAA` | The [activation protocol](https://docs.viam.com/data-ai/capture-data/lorawan/#activation-protocols) used to secure this network. Options: [`OTAA`, `ABP`] |
 | `uplink_interval_mins` | float64 | no | Defaults: `10` for the CT101, `1080` for EM310-TILT | Interval between uplink messages sent from the node, in minutes. Found in the device datasheet, but can be modified. Configured by downlink after initial connection. |
-| `gateways` | []string | yes | - | An array containing the name of the [gateway component](#add-a-gateway) in your Viam configuration. Alternatively, specify the gateway using the `Depends on` drop down. |
-| `fport` | string | no | `55` (aka `0x55`) | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
+| `fport` | string | no | - | 8-bit hexadecimal **frame port** used to send downlinks to the device. Found in the device datasheet. |
 
 #### OTAA Attributes
 
@@ -397,7 +400,7 @@ Send a generic downlink payload (in hexadecimal) to the node:
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that the peripheral is connected to. Used for GPIO pin control. |
-| `spi_bus` | int | no | 0 | SPI bus number used to connect the gateway peripheral. Options: [`0`, `1`] |
+| `spi_bus` | int | no | `0` | SPI bus number used to connect the gateway peripheral. Options: [`0`, `1`] |
 | `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |
 
 ### Configuration for `viam:lorawan:rak7391`
@@ -436,6 +439,7 @@ Use the returned SPI or serial paths in your viam configuration.
 | `pcie1` | config | no | - | PCIe configuration for concentrator connected to PCIe slot 1: <br> <ul><li>`spi_bus` (integer) (Optional): SPI bus that the concentrator is connected to, if connected through SPI. </li><li>`serial_path` (string) (Optional): Serial path that the concentrator is mounted at, if connected through USB. </li></ul> |
 | `pcie2` |config | no | - | PCIe configuration for concentrator connected to PCIe slot 2: <br> <ul><li>`spi_bus` (integer) (Optional): SPI bus that the concentrator is connected to, if connected through SPI. </li><li>`serial_path` (string) (Optional): Serial path that the concentrator is mounted at, if connected through USB. </li></ul> |
 
+You must specify at least one PCIe configuration.
 
 ### Configuration for `viam:lorawan:sx1302-hat-generic`
 
@@ -461,7 +465,7 @@ Note: To avoid a 15-minute reset loop, set the GPIO pins to the GPIO pin numbers
 |------|------|----------|---------|-------------|
 | `board` | string | yes | - | Name of the [board component](https://docs.viam.com/operate/reference/components/board/) that the peripheral is connected to. Used for GPIO pin control. |
 | `reset_pin` | int | yes | - | GPIO pin used for peripheral reset. |
-| `spi_bus` | int | no | 0 | SPI bus number used to connect the gateway peripheral. Options: [`0`, `1`]  |
+| `spi_bus` | int | no | `0` | SPI bus number used to connect the gateway peripheral. Options: [`0`, `1`]  |
 | `power_en_pin` | int | no | - | GPIO pin used for peripheral power enable. |
 | `path` | string | no | - | Serial path that the peripheral is mounted at, if connected through USB. |
 | `region_code` | string | no | `US915` | Frequency region of your gateway. Options: [`US915`, `EU868`] |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Send a generic downlink payload (in hexadecimal) to the node:
 }
 ```
 
-For more information about downlink commands, see the [LHT65 temperature sensor user guide](https://www.dragino.com/downloads/downloads/LHT65/UserManual/LHT65_Temperature_Humidity_Sensor_UserManual_v1.3.pdf).
+For more information about downlink commands, see the [LHT65 temperature sensor user manual](https://www.dragino.com/downloads/downloads/LHT65/UserManual/LHT65_Temperature_Humidity_Sensor_UserManual_v1.3.pdf) and the [WQS-LB user manual](https://wiki.dragino.com/xwiki/bin/view/Main/User%20Manual%20for%20LoRaWAN%20End%20Nodes/WQS-LB--LoRaWAN_Water_Quality_Sensor_Transmitter_User_Manual/).
 
 
 ### Configuration for `viam:lorawan:milesight-ct101` and `viam:lorawan:milesight-em310-tilt`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See below for the Viam configuration for each of these models.
 
 ### Configuration for `viam:lorawan:dragino-LHT65N` and `viam:lorawan:dragino-WQS-LB`
 
-Before using the Dragino WQS-LB, you must calibrate the sensor. For instructions on how to calibrate your sensor, see [the Viam documentation](https://docs.viam.com/operate/reference/components/sensor/lorawan/#calibrate-the-dragino-wqs-lb-water-quality-sensor)
+Before using the Dragino WQS-LB, you must calibrate the sensor. For instructions on how to calibrate your sensor, see [the Viam documentation](https://docs.viam.com/operate/reference/components/sensor/lorawan/#calibrate-the-dragino-wqs-lb-water-quality-sensor).
 
 #### Examples
 
@@ -107,7 +107,8 @@ Example ABP node configuration:
 | `dev_eui` | string | yes | - | The **device EUI (Extended Unique Identifier)**, a unique 64-bit identifier for the LoRaWAN device in hexadecimal format (16 characters). Found on your device or in device packaging. |
 | `app_key` | string | yes | - | The 128-bit hexadecimal AES **application key** used for device authentication and session key derivation. Found in the device datasheet. |
 
-NOTE: If using a WQS-LB, be sure to calibrate the sensor using the instructions below.
+> [!NOTE]
+> If you use the WQS-LB, be sure to [calibrate the sensor](https://docs.viam.com/operate/reference/components/sensor/lorawan/#calibrate-the-dragino-wqs-lb-water-quality-sensor).
 
 #### DoCommand
 

--- a/meta.json
+++ b/meta.json
@@ -9,7 +9,7 @@
       "api": "rdk:component:sensor",
       "model": "viam:lorawan:sx1302-hat-generic",
       "markdown_link": "README.md#configuration-for-viamlorawansx1302-hat-generic",
-      "short_description": "A sensor component for any SX1302-based LoRaWAN gateway HAT connected to a single board computer."
+      "short_description": "A generic sensor component for LoRaWAN gateway peripherals built using the SX1302 or SX1303 chips."
     },
     {
       "api": "rdk:component:sensor",
@@ -27,18 +27,18 @@
       "api": "rdk:component:sensor",
       "model": "viam:lorawan:node",
       "markdown_link": "README.md#configuration-for-viamlorawannode",
-      "short_description": "A sensor component for any generic LoRaWAN node."
+      "short_description": "A generic sensor component for any LoRaWAN node."
     },
     {
       "api": "rdk:component:sensor",
       "model": "viam:lorawan:dragino-LHT65N",
-      "markdown_link": "README.md#configuration-for-viamlorawandragino-LHT65N-and-viamlorawandragino-WQSLB",
+      "markdown_link": "README.md#configuration-for-viamlorawandragino-lht65n-and-viamlorawandragino-wqs-lb",
       "short_description": "A sensor component for a Dragino LHT65N LoRaWAN node."
     },
     {
       "api": "rdk:component:sensor",
       "model": "viam:lorawan:dragino-WQS-LB",
-      "markdown_link": "README.md#configuration-for-viamlorawandragino-LHT65N-and-viamlorawandragino-WQSLB",
+      "markdown_link": "README.md#configuration-for-viamlorawandragino-lht65n-and-viamlorawandragino-wqs-lb",
       "short_description": "A sensor component for a Dragino WQS-LB LoRaWAN node."
     },
     {


### PR DESCRIPTION
We decided to yank some of the tables out of the docs site and instead contribute the copy back to the single source of truth that is the README. This way, users will see these improvements in the app (and when linked from the docs) and we don't have to maintain two separate sets of tables.

Took the liberty of sprucing up some wording, flow, etc according to the docs style guide.

Hopefully nothing new or unexpected.