### PR TITLE
Add component name in low SNR warnings

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -64,6 +64,7 @@ var (
 	errInvalidRegion              = errors.New("unrecognized region code, valid options are US915 and EU868")
 	errInvalidConcentratorsLength = errors.New("invalid concentrator length - should not happen")
 	errTimedOut                   = errors.New("timed out waiting for gateway to start")
+	errLowSNR = errors.New("packet SNR below minimum threshold")
 )
 
 // constants for MHDRs of different message types.
@@ -745,12 +746,6 @@ func (g *gateway) receivePackets(ctx context.Context) {
 					if isDuplicate {
 						continue
 					}
-					minSNR := sfToSNRMin[packet.DataRate]
-					if float64(packet.SNR) < minSNR {
-						g.logger.Warnf("packet skipped due to low signal noise ratio: %v, min is %v", packet.SNR, minSNR)
-						continue
-					}
-
 					g.handlePacket(ctx, packet, t, c)
 				}
 			}
@@ -774,8 +769,8 @@ func (g *gateway) handlePacket(ctx context.Context, packet lorahw.RxPacket, pack
 	case unconfirmedUplinkMHdr:
 		name, readings, err := g.parseDataUplink(ctx, packet, packetTime, c)
 		if err != nil {
-			// don't log as error if it was a request from unknown device.
-			if errors.Is(errNoDevice, err) {
+			// don't log as error if it was a request from unknown device or low SNR.
+			if errors.Is(errNoDevice, err) || errors.Is(errLowSNR, err) {
 				return
 			}
 			g.logger.Errorf("error parsing uplink message: %v", err)
@@ -785,8 +780,8 @@ func (g *gateway) handlePacket(ctx context.Context, packet lorahw.RxPacket, pack
 	case confirmedUplinkMHdr:
 		name, readings, err := g.parseDataUplink(ctx, packet, packetTime, c)
 		if err != nil {
-			// don't log as error if it was a request from unknown device.
-			if errors.Is(errNoDevice, err) {
+			// don't log as error if it was a request from unknown device or low SNR.
+			if errors.Is(errNoDevice, err) || errors.Is(errLowSNR, err) {
 				return
 			}
 			g.logger.Errorf("error parsing uplink message: %v", err)

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -53,7 +53,13 @@ func (g *gateway) parseDataUplink(ctx context.Context, packet lorahw.RxPacket, p
 
 	device, err := matchDeviceAddr(devAddrBE, g.devices)
 	if err != nil {
-		g.logger.Debugf("received packet from unknown device, ignoring")
+		// Check if it's unknown due to poor SNR vs truly unknown device
+		minSNR := sfToSNRMin[packet.DataRate]
+		if float64(packet.SNR) < minSNR {
+			g.logger.Debugf("received packet from unknown device %X (likely due to poor SNR: %v, min is %v), ignoring", devAddrBE, packet.SNR, minSNR)
+		} else {
+			g.logger.Debugf("received packet from unknown device %X, ignoring", devAddrBE)
+		}
 		return "", map[string]interface{}{}, errNoDevice
 	}
 

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -56,7 +56,8 @@ func (g *gateway) parseDataUplink(ctx context.Context, packet lorahw.RxPacket, p
 		// Check if it's unknown due to poor SNR vs truly unknown device
 		minSNR := sfToSNRMin[packet.DataRate]
 		if float64(packet.SNR) < minSNR {
-			g.logger.Debugf("received packet from unknown device %X (likely due to poor SNR: %v, min is %v), ignoring", devAddrBE, packet.SNR, minSNR)
+			g.logger.Debugf("received packet from unknown device %X (likely due to poor SNR: %v, min is %v), ignoring",
+				devAddrBE, packet.SNR, minSNR)
 		} else {
 			g.logger.Debugf("received packet from unknown device %X, ignoring", devAddrBE)
 		}
@@ -66,7 +67,7 @@ func (g *gateway) parseDataUplink(ctx context.Context, packet lorahw.RxPacket, p
 	// Check SNR after device identification for better logging context
 	minSNR := sfToSNRMin[packet.DataRate]
 	if float64(packet.SNR) < minSNR {
-		g.logger.Warnf("packet from %s skipped due to low signal noise ratio: %v, min is %v", 
+		g.logger.Warnf("packet from %s skipped due to low signal noise ratio: %v, min is %v",
 			device.NodeName, packet.SNR, minSNR)
 		return "", map[string]interface{}{}, errLowSNR
 	}

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -57,6 +57,14 @@ func (g *gateway) parseDataUplink(ctx context.Context, packet lorahw.RxPacket, p
 		return "", map[string]interface{}{}, errNoDevice
 	}
 
+	// Check SNR after device identification for better logging context
+	minSNR := sfToSNRMin[packet.DataRate]
+	if float64(packet.SNR) < minSNR {
+		g.logger.Warnf("packet from %s skipped due to low signal noise ratio: %v, min is %v", 
+			device.NodeName, packet.SNR, minSNR)
+		return "", map[string]interface{}{}, errLowSNR
+	}
+
 	uplinkType := Unconfirmed
 	if phyPayload[0] == confirmedUplinkMHdr {
 		uplinkType = Confirmed


### PR DESCRIPTION
This PR moves the SNR validation from `receivePackets` to `parseDataUplink` after device identification, allowing us to include the component name in the log message:
```bash
7/16/2025, 5:06:49 PM warn rdk:component:sensor/gateway     gateway/uplink.go:63 packet from sensor-1 skipped due to low signal noise ratio: -13.25, min is -8.5   log_ts 2025-07-16T21:06:49.841Z
```

Currently, when packets are dropped due to low SNR (Signal-to-Noise Ratio), the log message doesn't identify which specific sensor/component is affected:
```bash
7/16/2025, 10:18:59 AM warn rdk:component:sensor/gateway     gateway/gateway.go:472 packet skipped due to low signal noise ratio: -11, min is -7.5   log_ts 2025-07-16T14:18:59.032Z
```

This makes it difficult to debug signal issues in deployments with multiple LoRaWAN sensors, as users can't tell which sensor needs attention.

After the change, the logging will show:

1. Known devices with low SNR:
```bash
packet from sensor-1 skipped due to low signal noise ratio: -13.25, min is -8.5   log_ts 2025-07-16T21:06:49.841Z
```

2. Unknown devices with low SNR (likely corrupted due to poor signal):
```bash
received packet from unknown device A84041EA01881AFF (likely due to poor SNR: -12, min is -7.5), ignoring
```

3. Unknown devices with good SNR (truly unknown devices):
```bash
received packet from unknown device B12345678901234, ignoring
```