### PR TITLE
RSDK-11545 allow deploy workflow to run on all releases 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 on:
-  push:
-    tags:
-    - '[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
The previous deploy workflow followed a pattern to only deploy on tags with x.x.x, so RC releases were not included. Changing to match the[ orbbec ](https://github.com/viam-modules/orbbec/blob/39ac33cd5945ec7ae9f0f69df047b11fa0015631/.github/workflows/publish.yml#L5) module workflow so the deploy in run on all releases.